### PR TITLE
Error check cleanup

### DIFF
--- a/pywincffi/core/ffi.py
+++ b/pywincffi/core/ffi.py
@@ -124,6 +124,11 @@ def error_check(api_function, code=None, expected=0):
         An explicit code to compare against.  This can be used
         instead of asking :func:`ffi.getwinerrro` to retrieve a code.
 
+    :param int expected:
+        The code we expect to have as a result of a successful
+        call.  This can also be passed ``pywincffi.ffi.NON_ZERO`` if
+        ``code`` can be anything but zero.
+
     :raises pywincffi.exceptions.WindowsAPIError:
         Raised if we receive an unexpected result from a Windows API call
     """

--- a/pywincffi/core/ffi.py
+++ b/pywincffi/core/ffi.py
@@ -120,8 +120,9 @@ def error_check(api_function, code=None, expected=0):
     :param str api_function:
         The Windows API function being called.
 
-    :param code:
-
+    :param int code:
+        An explicit code to compare against.  This can be used
+        instead of asking :func:`ffi.getwinerrro` to retrieve a code.
 
     :raises pywincffi.exceptions.WindowsAPIError:
         Raised if we receive an unexpected result from a Windows API call

--- a/pywincffi/core/ffi.py
+++ b/pywincffi/core/ffi.py
@@ -17,6 +17,8 @@ from pywincffi.core.logger import logger
 from pywincffi.exceptions import (
     InputError, WindowsAPIError, HeaderNotFoundError)
 
+NON_ZERO = object()
+
 
 class Library(object):
     """
@@ -109,34 +111,41 @@ class Library(object):
         return library
 
 
-def error_check(api_function, code=None, expected=0, nonzero=False):
+def error_check(api_function, code=None, expected=0):
     """
     Checks the results of a return code against an expected result.  If
     a code is not provided we'll use :func:`ffi.getwinerror` to retrieve
     the code.
 
     :param str api_function:
-        The Windows API function being caled.
+        The Windows API function being called.
+
+    :param code:
+
 
     :raises pywincffi.exceptions.WindowsAPIError:
         Raised if we receive an unexpected result from a Windows API call
     """
     if code is None:
-        code, api_error_message = ffi.getwinerror()
+        result, api_error_message = ffi.getwinerror()
     else:
-        code, api_error_message = ffi.getwinerror(code)
+        result, api_error_message = ffi.getwinerror(code)
+
+    expected_str = expected
+    if expected is NON_ZERO:
+        expected_str = "non-zero"
 
     logger.debug(
-        "error_check(%r, code=%r, expected=%r)",
-        api_function, code, expected
+        "error_check(%r, code=%r, result=%r, expected=%r)",
+        api_function, code, result, expected_str
     )
 
-    if nonzero and code != 0:
+    if expected is NON_ZERO and (result != 0 or code is not None and code != 0):
         return
 
-    if nonzero and code == 0 or code != expected:
+    if expected != result:
         raise WindowsAPIError(
-            api_function, api_error_message, code, expected, nonzero=nonzero
+            api_function, api_error_message, result, expected
         )
 
 

--- a/pywincffi/exceptions.py
+++ b/pywincffi/exceptions.py
@@ -33,22 +33,19 @@ class WindowsAPIError(PyWinCFFIError):
     A subclass of :class:`PyWinCFFIError` that's raised when there was a
     problem calling a Windows API function.
     """
-    def __init__(
-            self, api_function, api_error_message, code, expected_code,
-            nonzero=False
-    ):
+    def __init__(self, api_function, api_error_message, code, expected_code):
         self.api_function = api_function
         self.api_error_message = api_error_message
         self.code = code
         self.expected_code = expected_code
-        self.nonzero = nonzero
 
-        if not self.nonzero:
+        # We can't import the ffi module here because it would result
+        # in a circular import so we exclude the two other cases (int and None).
+        if not isinstance(expected_code, int) and expected_code is not None:
             self.message = \
                 "Error when calling %s, error was %r.  Received " \
-                "return value %s when we expected %s." % (
-                self.api_function, self.api_error_message, self.code,
-                self.expected_code
+                "return value %s when we expected non-zero" % (
+                self.api_function, self.api_error_message, self.code
             )
         else:
             self.message = \

--- a/tests/test_core/test_ffi.py
+++ b/tests/test_core/test_ffi.py
@@ -9,7 +9,8 @@ from mock import Mock, patch
 from six.moves import builtins
 
 import pywincffi
-from pywincffi.core.ffi import Library, new_ffi, ffi, input_check, error_check
+from pywincffi.core.ffi import (
+    NON_ZERO, Library, new_ffi, ffi, input_check, error_check)
 from pywincffi.core.testutil import TestCase
 from pywincffi.exceptions import (
     WindowsAPIError, InputError, HeaderNotFoundError)
@@ -116,13 +117,13 @@ class TestCheckErrorCode(TestCase):
             with self.assertRaises(WindowsAPIError):
                 error_check("Foobar", expected=2)
 
-    def test_non_zero_error(self):
-        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
-            with self.assertRaises(WindowsAPIError):
-                error_check("Foobar", nonzero=True)
+    def test_non_zero(self):
+        with patch.object(ffi, "getwinerror", return_value=(1, "NGTG")):
+            error_check("Foobar", expected=NON_ZERO)
 
-    def test_non_zero_failure(self):
-        error_check("Foobar", code=1, nonzero=True)
+    def test_non_zero_success(self):
+        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
+            error_check("Foobar", code=1, expected=NON_ZERO)
 
 
 class TestTypeCheck(TestCase):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -56,11 +56,6 @@ class TestWindowsAPIError(TestCase):
         error = WindowsAPIError("function", "there was a problem", 1, 0)
         self.assertEqual(error.expected_code, 0)
 
-    def test_ivar_non_zero(self):
-        error = WindowsAPIError(
-            "function", "there was a problem", 1, 0, nonzero=-1)
-        self.assertEqual(error.nonzero, -1)
-
     def test_str(self):
         error = WindowsAPIError("function", "there was a problem", 1, 0)
         self.assertEqual(str(error), error.message)


### PR DESCRIPTION
The `error_check()` function had both a `nonzero` keyword an an `expected` keyword.  To avoid confusion there should be a special value that can be passed into `expected` that will account for the non-zero case.
