### PR TITLE
Lock Down Mock Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,14 @@ py_major, py_minor = sys.version_info[0:2]
 if py_major == 2:
     tests_require.append("unittest2")
 
-if py_minor == 7:
-    tests_require.append("mock")
-
-if py_minor == 6:
+if py_major == 2 and py_minor == 6:
     tests_require.append("mock==1.0.1")
+
+else:
+    try:
+        from unittest import mock
+    except ImportError:
+        tests_require.append("mock")
 
 # Running on buildbot
 if "BB_BUILDSLAVE" in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,18 @@ install_requires_extras = []
 if "READTHEDOCS" in os.environ:
     install_requires_extras = ["sphinx"]
 
-tests_require = ["nose", "coverage", "mock"]
-if sys.version_info[0:2] == (2, 6):
+tests_require = ["nose", "coverage"]
+
+py_major, py_minor = sys.version_info[0:2]
+
+if py_major == 2:
     tests_require.append("unittest2")
+
+if py_minor == 7:
+    tests_require.append("mock")
+
+if py_minor == 6:
+    tests_require.append("mock==1.0.1")
 
 # Running on buildbot
 if "BB_BUILDSLAVE" in os.environ:

--- a/tests/test_core/test_ffi.py
+++ b/tests/test_core/test_ffi.py
@@ -1,8 +1,12 @@
 from textwrap import dedent
 from os.path import dirname, join
 
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
 from cffi import FFI
-from mock import Mock, patch
 from six.moves import builtins
 
 import pywincffi

--- a/tests/test_core/test_ffi.py
+++ b/tests/test_core/test_ffi.py
@@ -1,6 +1,3 @@
-import os
-import sys
-import tempfile
 from textwrap import dedent
 from os.path import dirname, join
 
@@ -14,7 +11,6 @@ from pywincffi.core.ffi import (
 from pywincffi.core.testutil import TestCase
 from pywincffi.exceptions import (
     WindowsAPIError, InputError, HeaderNotFoundError)
-
 
 
 class TestFFI(TestCase):


### PR DESCRIPTION
The mock package, which we use in a few tests and is required for Python < 3.0, stopped supporting Python 2.6 as of version 1.0.x:

```
======================================================================
ERROR: Failure: SyntaxError (invalid syntax (mock.py, line 132))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\virtualenv\lib\site-packages\nose\loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\virtualenv\lib\site-packages\nose\importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\virtualenv\lib\site-packages\nose\importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\tests\test_files.py", line 1, in <module>
    from mock import patch
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\virtualenv\lib\site-packages\mock\__init__.py", line 2, in <module>
    import mock.mock as _mock
  File "C:\buildbot\slave\pywincffi-cpython-2_6_6-64\build\virtualenv\lib\site-packages\mock\mock.py", line 132
    _builtins = {name for name in dir(builtins) if not name.startswith('_')}
                        ^
SyntaxError: invalid syntax
```

This PR fixes this by locking down the version when running Python 2.6.
