### PR TITLE
Move input/output checks into their own module.

### DIFF
--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -3,10 +3,10 @@ import enum
 from six import string_types
 
 from pywincffi.core.ffi import ffi
-from pywincffi.core.logger import logger
+from pywincffi.core.logger import get_logger
 from pywincffi.exceptions import WindowsAPIError, InputError
 
-logger = logger.getChild("core.check")
+logger = get_logger("core.check")
 
 Enums = enum.Enum("Enums", " ".join([
     "NON_ZERO",

--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -96,9 +96,5 @@ def input_check(name, value, allowed_types):
 
         return
 
-    # A new named type was provided for `allowed_types`,
-    # be sure to update the docs for `allowed_types`
-    assert not isinstance(allowed_types, string_types)
-
     if not isinstance(value, allowed_types):
         raise InputError(name, value, allowed_types)

--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -1,0 +1,107 @@
+from collections import namedtuple
+
+from six import string_types
+
+from pywincffi.core.ffi import ffi
+from pywincffi.core.logger import logger
+from pywincffi.exceptions import WindowsAPIError, InputError
+
+logger = logger.getChild("core.check")
+_Enums = namedtuple("_Enums", ("NON_ZERO", ))
+Enums = _Enums(
+    NON_ZERO=object()
+)
+
+
+def error_check(api_function, code=None, expected=0):
+    """
+    Checks the results of a return code against an expected result.  If
+    a code is not provided we'll use :func:`ffi.getwinerror` to retrieve
+    the code.
+
+    :param str api_function:
+        The Windows API function being called.
+
+    :param int code:
+        An explicit code to compare against.  This can be used
+        instead of asking :func:`ffi.getwinerrro` to retrieve a code.
+
+    :param int expected:
+        The code we expect to have as a result of a successful
+        call.  This can also be passed ``pywincffi.ffi.NON_ZERO`` if
+        ``code`` can be anything but zero.
+
+    :raises pywincffi.exceptions.WindowsAPIError:
+        Raised if we receive an unexpected result from a Windows API call
+    """
+    if code is None:
+        result, api_error_message = ffi.getwinerror()
+    else:
+        result, api_error_message = ffi.getwinerror(code)
+
+    expected_str = expected
+    if expected is Enums.NON_ZERO:
+        expected_str = "non-zero"
+
+    logger.debug(
+        "error_check(%r, code=%r, result=%r, expected=%r)",
+        api_function, code, result, expected_str
+    )
+
+    if (expected is Enums.NON_ZERO
+        and (result != 0 or code is not None and code != 0)):
+        return
+
+    if expected != result:
+        raise WindowsAPIError(
+            api_function, api_error_message, result, expected
+        )
+
+
+def input_check(name, value, allowed_types):
+    """
+    A small wrapper around :func:`isinstance`.  This is mainly meant
+    to be used inside of other functions to pre-validate input rater
+    than using assertions.  It's better to fail early with bad input
+    so more reasonable error message can be provided instead of from
+    somewhere deep in cffi or Windows.
+
+    :param str name:
+        The name of the input being checked.  This is provided
+        so error messages make more sense and can be attributed
+        to specific input arguments.
+
+    :param value:
+        The value we're performing the type check on.
+
+    :param allowed_types:
+        The allowed type or types for ``value``.  This argument
+        also supports a string for `allowed_types` called 'handle'
+        to validate ctype handle declarations.
+
+    :raises pywincffi.exceptions.InputError:
+        Raised if ``value`` is not an instance of ``allowed_types``
+    """
+    assert isinstance(name, string_types)
+
+    logger.debug(
+        "input_check(name=%r, value=%r, allowed_types=%r",
+        name, value, allowed_types
+    )
+    if allowed_types == "handle":
+        try:
+            typeof = ffi.typeof(value)
+            if typeof.kind != "pointer" or typeof.cname != "void *":
+                raise TypeError
+
+        except TypeError:
+            raise InputError(name, value, allowed_types)
+
+        return
+
+    # A new named type was provided for `allowed_types`,
+    # be sure to update the docs for `allowed_types`
+    assert not isinstance(allowed_types, string_types)
+
+    if not isinstance(value, allowed_types):
+        raise InputError(name, value, allowed_types)

--- a/pywincffi/core/ffi.py
+++ b/pywincffi/core/ffi.py
@@ -3,21 +3,18 @@ FFI
 ---
 
 This module is mainly responsible for loading and configuring
-:mod:`cffi`.  It's also responsible for some auxiliary
-funcnaility as well.
+:mod:`cffi`.
 """
 
 from errno import ENOENT
 
-import six
 from cffi import FFI
 from pkg_resources import resource_filename
 
 from pywincffi.core.logger import logger
-from pywincffi.exceptions import (
-    InputError, WindowsAPIError, HeaderNotFoundError)
+from pywincffi.exceptions import HeaderNotFoundError
 
-NON_ZERO = object()
+logger = logger.getChild("core.ffi")
 
 
 class Library(object):
@@ -109,99 +106,6 @@ class Library(object):
         instance_cache = cls.CACHE.setdefault(ffi_instance, {})
         instance_cache[library_name] = library
         return library
-
-
-def error_check(api_function, code=None, expected=0):
-    """
-    Checks the results of a return code against an expected result.  If
-    a code is not provided we'll use :func:`ffi.getwinerror` to retrieve
-    the code.
-
-    :param str api_function:
-        The Windows API function being called.
-
-    :param int code:
-        An explicit code to compare against.  This can be used
-        instead of asking :func:`ffi.getwinerrro` to retrieve a code.
-
-    :param int expected:
-        The code we expect to have as a result of a successful
-        call.  This can also be passed ``pywincffi.ffi.NON_ZERO`` if
-        ``code`` can be anything but zero.
-
-    :raises pywincffi.exceptions.WindowsAPIError:
-        Raised if we receive an unexpected result from a Windows API call
-    """
-    if code is None:
-        result, api_error_message = ffi.getwinerror()
-    else:
-        result, api_error_message = ffi.getwinerror(code)
-
-    expected_str = expected
-    if expected is NON_ZERO:
-        expected_str = "non-zero"
-
-    logger.debug(
-        "error_check(%r, code=%r, result=%r, expected=%r)",
-        api_function, code, result, expected_str
-    )
-
-    if expected is NON_ZERO and (result != 0 or code is not None and code != 0):
-        return
-
-    if expected != result:
-        raise WindowsAPIError(
-            api_function, api_error_message, result, expected
-        )
-
-
-def input_check(name, value, allowed_types):
-    """
-    A small wrapper around :func:`isinstance`.  This is mainly meant
-    to be used inside of other functions to pre-validate input rater
-    than using assertions.  It's better to fail early with bad input
-    so more reasonable error message can be provided instead of from
-    somewhere deep in cffi or Windows.
-
-    :param str name:
-        The name of the input being checked.  This is provided
-        so error messages make more sense and can be attributed
-        to specific input arguments.
-
-    :param value:
-        The value we're performing the type check on.
-
-    :param allowed_types:
-        The allowed type or types for ``value``.  This argument
-        also supports a string for `allowed_types` called 'handle'
-        to validate ctype handle declarations.
-
-    :raises pywincffi.exceptions.InputError:
-        Raised if ``value`` is not an instance of ``allowed_types``
-    """
-    assert isinstance(name, six.string_types)
-
-    logger.debug(
-        "input_check(name=%r, value=%r, allowed_types=%r",
-        name, value, allowed_types
-    )
-    if allowed_types == "handle":
-        try:
-            typeof = ffi.typeof(value)
-            if typeof.kind != "pointer" or typeof.cname != "void *":
-                raise TypeError
-
-        except TypeError:
-            raise InputError(name, value, allowed_types)
-
-        return
-
-    # A new named type was provided for `allowed_types`,
-    # be sure to update the docs for `allowed_types`
-    assert not isinstance(allowed_types, six.string_types)
-
-    if not isinstance(value, allowed_types):
-        raise InputError(name, value, allowed_types)
 
 
 def new_ffi():

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -16,7 +16,9 @@ documentation for the constant names and their purpose:
 """
 
 import six
-from pywincffi.core.ffi import Library, ffi, input_check, error_check
+
+from pywincffi.core.ffi import Library, ffi
+from pywincffi.core.checks import input_check, error_check
 
 kernel32 = Library.load("kernel32")
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ else:
     except ImportError:
         tests_require.append("mock")
 
+if (py_major, py_minor) < (3, 4):
+    install_requires_extras.append("enum34")
+
+
 # Running on buildbot
 if "BB_BUILDSLAVE" in os.environ:
     install_requires_extras += tests_require

--- a/tests/test_core/test_checks.py
+++ b/tests/test_core/test_checks.py
@@ -1,0 +1,60 @@
+from textwrap import dedent
+from os.path import dirname, join
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
+from pywincffi.core.checks import Enums, input_check, error_check
+from pywincffi.core.ffi import ffi
+from pywincffi.core.testutil import TestCase
+from pywincffi.exceptions import WindowsAPIError, InputError
+
+
+class TestCheckErrorCode(TestCase):
+    """
+    Tests for :func:`pywincffi.core.ffi.check_error_code`
+    """
+    def test_default_code_does_match_expected(self):
+        with patch.object(ffi, "getwinerror", return_value=(0, "GTG")):
+            error_check("Foobar")
+
+    def test_default_code_does_not_match_expected(self):
+        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
+            with self.assertRaises(WindowsAPIError):
+                error_check("Foobar", expected=2)
+
+    def test_non_zero(self):
+        with patch.object(ffi, "getwinerror", return_value=(1, "NGTG")):
+            error_check("Foobar", expected=Enums.NON_ZERO)
+
+    def test_non_zero_success(self):
+        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
+            error_check("Foobar", code=1, expected=Enums.NON_ZERO)
+
+
+class TestTypeCheck(TestCase):
+    """
+    Tests for :func:`pywincffi.core.types.input_check`
+    """
+    def test_type_error(self):
+        with self.assertRaises(InputError):
+            input_check("foobar", 1, str)
+
+    def test_handle_type_failure(self):
+        with self.assertRaises(InputError):
+            input_check("", None, "handle")
+
+    def test_not_a_handle(self):
+        typeof = Mock(kind="", cname="")
+        with patch.object(ffi, "typeof", return_value=typeof):
+            with self.assertRaises(InputError):
+                input_check("", None, "handle")
+
+    def test_handle_type_success(self):
+        typeof = Mock(kind="pointer", cname="void *")
+        with patch.object(ffi, "typeof", return_value=typeof):
+            # The value does not matter here since we're
+            # mocking out typeof()
+            input_check("", None, "handle")

--- a/tests/test_core/test_checks.py
+++ b/tests/test_core/test_checks.py
@@ -44,17 +44,17 @@ class TestTypeCheck(TestCase):
 
     def test_handle_type_failure(self):
         with self.assertRaises(InputError):
-            input_check("", None, "handle")
+            input_check("", None, Enums.HANDLE)
 
     def test_not_a_handle(self):
         typeof = Mock(kind="", cname="")
         with patch.object(ffi, "typeof", return_value=typeof):
             with self.assertRaises(InputError):
-                input_check("", None, "handle")
+                input_check("", None, Enums.HANDLE)
 
     def test_handle_type_success(self):
         typeof = Mock(kind="pointer", cname="void *")
         with patch.object(ffi, "typeof", return_value=typeof):
             # The value does not matter here since we're
             # mocking out typeof()
-            input_check("", None, "handle")
+            input_check("", None, Enums.HANDLE)

--- a/tests/test_core/test_ffi.py
+++ b/tests/test_core/test_ffi.py
@@ -10,11 +10,9 @@ from cffi import FFI
 from six.moves import builtins
 
 import pywincffi
-from pywincffi.core.ffi import (
-    NON_ZERO, Library, new_ffi, ffi, input_check, error_check)
+from pywincffi.core.ffi import Library, new_ffi, ffi
 from pywincffi.core.testutil import TestCase
-from pywincffi.exceptions import (
-    WindowsAPIError, InputError, HeaderNotFoundError)
+from pywincffi.exceptions import HeaderNotFoundError
 
 
 class TestFFI(TestCase):
@@ -102,51 +100,3 @@ class TestLibraryLoad(TestCase):
 
         self.assertIs(Library.CACHE[ffi]["kernel32"], library1)
         self.assertIs(Library.CACHE[ffi]["kernel32"], library2)
-
-
-class TestCheckErrorCode(TestCase):
-    """
-    Tests for :func:`pywincffi.core.ffi.check_error_code`
-    """
-    def test_default_code_does_match_expected(self):
-        with patch.object(ffi, "getwinerror", return_value=(0, "GTG")):
-            error_check("Foobar")
-
-    def test_default_code_does_not_match_expected(self):
-        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
-            with self.assertRaises(WindowsAPIError):
-                error_check("Foobar", expected=2)
-
-    def test_non_zero(self):
-        with patch.object(ffi, "getwinerror", return_value=(1, "NGTG")):
-            error_check("Foobar", expected=NON_ZERO)
-
-    def test_non_zero_success(self):
-        with patch.object(ffi, "getwinerror", return_value=(0, "NGTG")):
-            error_check("Foobar", code=1, expected=NON_ZERO)
-
-
-class TestTypeCheck(TestCase):
-    """
-    Tests for :func:`pywincffi.core.types.input_check`
-    """
-    def test_type_error(self):
-        with self.assertRaises(InputError):
-            input_check("foobar", 1, str)
-
-    def test_handle_type_failure(self):
-        with self.assertRaises(InputError):
-            input_check("", None, "handle")
-
-    def test_not_a_handle(self):
-        typeof = Mock(kind="", cname="")
-        with patch.object(ffi, "typeof", return_value=typeof):
-            with self.assertRaises(InputError):
-                input_check("", None, "handle")
-
-    def test_handle_type_success(self):
-        typeof = Mock(kind="pointer", cname="void *")
-        with patch.object(ffi, "typeof", return_value=typeof):
-            # The value does not matter here since we're
-            # mocking out typeof()
-            input_check("", None, "handle")


### PR DESCRIPTION
This PR splits out `error_check()` and `input_check()` into their own modules and also uses enums rather than straight strings for special types (less likely to introduce typos).
