### PR TITLE
Basic tests for header files

### DIFF
--- a/pywincffi/core/cdefs/headers/constants.h
+++ b/pywincffi/core/cdefs/headers/constants.h
@@ -2,6 +2,10 @@
 // This file contains constants which can be used either internally or
 // by users of pywincffi.
 //
+// NOTE: The tests for this file, tests/test_core/test_cdefs/test_constants.py
+//       depend on a constant's names to follow this format:
+//           #define NAME ...
+//
 
 #define MAX_PATH ...
 #define PROCESS_CREATE_PROCESS ...

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -1,3 +1,10 @@
+//
+// NOTE: The tests for this file, tests/test_core/test_cdefs/test_functions.py
+//       depend on a function's format to be the following:
+//           RETURN_TYPE FunctionName(...
+//
+
+
 // Processes
 HANDLE OpenProcess(DWORD, BOOL, DWORD);
 

--- a/pywincffi/core/cdefs/headers/structs.h
+++ b/pywincffi/core/cdefs/headers/structs.h
@@ -1,3 +1,9 @@
+//
+// NOTE: The tests for this file, tests/test_core/test_cdefs/test_structs.py
+//       depend on a struct's names to follow this format:
+//           } NAME, NAME, NAME;
+//
+
 typedef struct _SECURITY_ATTRIBUTES {
     DWORD  nLength;
     LPVOID lpSecurityDescriptor;
@@ -16,4 +22,3 @@ typedef struct _OVERLAPPED {
   };
   HANDLE    hEvent;
 } OVERLAPPED, *LPOVERLAPPED;
-

--- a/pywincffi/core/testutil.py
+++ b/pywincffi/core/testutil.py
@@ -19,6 +19,8 @@ if sys.version_info[0:2] == (2, 6):
 else:
     from unittest import TestCase as _TestCase
 
+from pywincffi.core.ffi import Library
+
 # Load in our own kernel32 with the function(s) we need
 # so we don't have to rely on pywincffi.core
 ffi = FFI()
@@ -55,3 +57,33 @@ class TestCase(_TestCase):
         except (OSError, IOError, WindowsError) as e:
             if e.errno != ENOENT and onexit:
                 atexit.register(self.remove, path, onexit=False)
+
+
+class HeaderFileDefinitionTestCase(_TestCase):
+    """
+    Used to test header definitions against our library.
+    """
+    # The full path to the header file we're testing
+    HEADER = None
+
+    def setUp(self):
+        if self.HEADER is None:
+            self.skipTest("HEADER not set")
+
+        with open(self.HEADER, "r") as header_file:
+            self.header = header_file.read()
+
+        self.ffi, self.library = Library.load()
+
+    def get_definitions(self):
+        pass
+
+    def test_definitions(self):
+        definitions = self.get_definitions()
+
+        if definitions is None:
+            self.skipTest("No definitions provided.")
+
+        if not definitions:
+            self.fail("No definitions found")
+

--- a/pywincffi/core/testutil.py
+++ b/pywincffi/core/testutil.py
@@ -19,8 +19,6 @@ if sys.version_info[0:2] == (2, 6):
 else:
     from unittest import TestCase as _TestCase
 
-from pywincffi.core.ffi import Library
-
 # Load in our own kernel32 with the function(s) we need
 # so we don't have to rely on pywincffi.core
 ffi = FFI()
@@ -57,33 +55,4 @@ class TestCase(_TestCase):
         except (OSError, IOError, WindowsError) as e:
             if e.errno != ENOENT and onexit:
                 atexit.register(self.remove, path, onexit=False)
-
-
-class HeaderFileDefinitionTestCase(_TestCase):
-    """
-    Used to test header definitions against our library.
-    """
-    # The full path to the header file we're testing
-    HEADER = None
-
-    def setUp(self):
-        if self.HEADER is None:
-            self.skipTest("HEADER not set")
-
-        with open(self.HEADER, "r") as header_file:
-            self.header = header_file.read()
-
-        self.ffi, self.library = Library.load()
-
-    def get_definitions(self):
-        pass
-
-    def test_definitions(self):
-        definitions = self.get_definitions()
-
-        if definitions is None:
-            self.skipTest("No definitions provided.")
-
-        if not definitions:
-            self.fail("No definitions found")
 

--- a/tests/test_core/test_cdefs/__init__.py
+++ b/tests/test_core/test_cdefs/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'opalmer'

--- a/tests/test_core/test_cdefs/__init__.py
+++ b/tests/test_core/test_cdefs/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'opalmer'

--- a/tests/test_core/test_cdefs/test_constants.py
+++ b/tests/test_core/test_cdefs/test_constants.py
@@ -1,0 +1,30 @@
+import re
+from os.path import isfile, join
+
+from pywincffi.core.ffi import Library
+from pywincffi.core.testutil import TestCase
+
+
+class TestConstantsHeader(TestCase):
+    def test_file_exists(self):
+        for path in Library.HEADERS:
+            if path.endswith("constants.h"):
+                self.assertTrue(isfile(path))
+
+    def get_constants(self):
+        with open(join(Library.HEADERS_ROOT, "constants.h"), "r") as header:
+            for line in header:
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+
+                match = re.match("^#define ([A-Z_]*) \.\.\..*$", line)
+                if match is not None:
+                    yield match.group(1)
+
+    def test_library_has_attributes_defined_in_header(self):
+        ffi, library = Library.load()
+        for constant_name in self.get_constants():
+            self.assertTrue(hasattr(library, constant_name))
+
+

--- a/tests/test_core/test_cdefs/test_constants.py
+++ b/tests/test_core/test_cdefs/test_constants.py
@@ -7,11 +7,15 @@ from pywincffi.core.ffi import Library
 from pywincffi.core.testutil import TestCase
 
 
+# TODO: it would be better if we had a parser to parse the header
 class TestConstantsHeader(TestCase):
     def test_file_exists(self):
         for path in Library.HEADERS:
             if path.endswith("constants.h"):
                 self.assertTrue(isfile(path))
+                break
+        else:
+            self.fail("Failed to locate header in Library.HEADERS")
 
     def get_constants(self):
         with open(join(Library.HEADERS_ROOT, "constants.h"), "r") as header:
@@ -26,6 +30,7 @@ class TestConstantsHeader(TestCase):
 
     def test_library_has_attributes_defined_in_header(self):
         ffi, library = Library.load()
+
         for constant_name in self.get_constants():
             self.assertTrue(hasattr(library, constant_name))
 

--- a/tests/test_core/test_cdefs/test_constants.py
+++ b/tests/test_core/test_cdefs/test_constants.py
@@ -1,6 +1,8 @@
 import re
 from os.path import isfile, join
 
+from six import integer_types
+
 from pywincffi.core.ffi import Library
 from pywincffi.core.testutil import TestCase
 
@@ -27,4 +29,9 @@ class TestConstantsHeader(TestCase):
         for constant_name in self.get_constants():
             self.assertTrue(hasattr(library, constant_name))
 
+    def test_constant_type(self):
+        ffi, library = Library.load()
+        valid_types = tuple(list(integer_types) + [bool])
 
+        for constant_name in self.get_constants():
+            self.assertIsInstance(getattr(library, constant_name), valid_types)

--- a/tests/test_core/test_cdefs/test_functions.py
+++ b/tests/test_core/test_cdefs/test_functions.py
@@ -1,0 +1,35 @@
+import re
+from os.path import isfile, join
+
+from pywincffi.core.ffi import Library
+from pywincffi.core.testutil import TestCase
+
+
+class TestFunctionsHeader(TestCase):
+    def test_file_exists(self):
+        for path in Library.HEADERS:
+            if path.endswith("functions.h"):
+                self.assertTrue(isfile(path))
+
+    def get_header_functions(self):
+        with open(join(Library.HEADERS_ROOT, "functions.h"), "r") as header:
+            for line in header:
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+
+                match = re.match("^[A-Z]* ([A-Za-z]*)\(.*\);$", line)
+                if match is not None:
+                    yield match.group(1)
+
+    def test_library_has_attributes_defined_in_header(self):
+        ffi, library = Library.load()
+        for function_name in self.get_header_functions():
+            self.assertTrue(hasattr(library, function_name))
+
+    def test_library_has_functions_defined_in_header(self):
+        ffi, library = Library.load()
+        for function_name in self.get_header_functions():
+            function = getattr(library, function_name)
+            self.assertTrue(callable(function))
+

--- a/tests/test_core/test_cdefs/test_functions.py
+++ b/tests/test_core/test_cdefs/test_functions.py
@@ -5,11 +5,15 @@ from pywincffi.core.ffi import Library
 from pywincffi.core.testutil import TestCase
 
 
+# TODO: it would be better if we had a parser to parse the header
 class TestFunctionsHeader(TestCase):
     def test_file_exists(self):
         for path in Library.HEADERS:
             if path.endswith("functions.h"):
                 self.assertTrue(isfile(path))
+                break
+        else:
+            self.fail("Failed to locate header in Library.HEADERS")
 
     def get_header_functions(self):
         with open(join(Library.HEADERS_ROOT, "functions.h"), "r") as header:
@@ -24,11 +28,13 @@ class TestFunctionsHeader(TestCase):
 
     def test_library_has_attributes_defined_in_header(self):
         ffi, library = Library.load()
+
         for function_name in self.get_header_functions():
             self.assertTrue(hasattr(library, function_name))
 
     def test_library_has_functions_defined_in_header(self):
         ffi, library = Library.load()
+
         for function_name in self.get_header_functions():
             function = getattr(library, function_name)
             self.assertTrue(callable(function))

--- a/tests/test_core/test_cdefs/test_structs.py
+++ b/tests/test_core/test_cdefs/test_structs.py
@@ -1,0 +1,49 @@
+from os.path import isfile, join
+
+from pywincffi.core.ffi import Library
+from pywincffi.core.testutil import TestCase
+
+
+# TODO: it would be better if we had a parser to parse the header
+class TestStructsHeader(TestCase):
+    def test_file_exists(self):
+        for path in Library.HEADERS:
+            if path.endswith("structs.h"):
+                self.assertTrue(isfile(path))
+                break
+        else:
+            self.fail("Failed to locate header in Library.HEADERS")
+
+    def test_get_structs(self):
+        with open(join(Library.HEADERS_ROOT, "structs.h"), "r") as header:
+            for line in header:
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+
+                # This is a bit hacky but it's effective...
+                if line.startswith("}") and line.endswith(";"):
+
+                    for char in ("}", ";", "*", " "):
+                        line = line.replace(char, "")
+
+                    for entry in filter(bool, line.strip().split(",")):
+                        yield entry
+
+    def test_library_has_attributes_defined_in_header(self):
+        ffi, library = Library.load()
+        
+        for struct_name in self.test_get_structs():
+            try:
+                ffi.new(struct_name)
+
+            # If the struct is not a pointer then we heed to call ffi.new
+            # in a different way.  We could test to see if the name starts with
+            # * but this is slightly better because it ties is less into the
+            # syntax and more into the behavior of ffi.new.
+            except TypeError as error:
+                self.assertEqual(
+                    str(error),
+                    "expected a pointer or array ctype, got '%s'" % struct_name)
+                ffi.new("%s[0]" % struct_name)
+

--- a/tests/test_core/test_ffi.py
+++ b/tests/test_core/test_ffi.py
@@ -7,9 +7,7 @@ except ImportError:
     from mock import Mock, patch
 
 from cffi import FFI
-from six.moves import builtins
 
-import pywincffi
 from pywincffi.core.ffi import Library
 from pywincffi.core.testutil import TestCase
 from pywincffi.exceptions import ResourceNotFoundError

--- a/tests/test_kernel32/__init__.py
+++ b/tests/test_kernel32/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'opalmer'


### PR DESCRIPTION
This PR adds some additional tests of the header files.  This mainly is here to ensure that items such as functions, constants and structures end up on the loaded library object.  Without this we could end up with an untested constant not appearing in the library for some reason which is important as some of that information may be a part of the library but not directly tested.  This is also helpful from a development perspective to ensure the way we're loading the library is working to some extent.
