### PR TITLE
Build With AppVeyor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Python Windows Wrapper Using CFFI
 =================================
 
+[![Build status](https://ci.appveyor.com/api/projects/status/dl0ec1fny9keo61c?svg=true)](https://ci.appveyor.com/project/opalmer/pywincffi)
+
+
 This library is a wrapper around some Windows functions using Python 
 and CFFI.  The repository was originally created to assist the Twisted
 project in moving away from pywin32 so installation does not require a compile
@@ -72,7 +75,9 @@ the ``setup.py`` file::
     pip install -e .
     python setup.py test
 
-Every build is also executed on https://build.opalmer.com/ and you could
-use ``nosetests`` directly if you wish as well::
+Every commit and pull request is also executed on
+[AppVeyor](https://ci.appveyor.com/project/opalmer/pywincffi).  Tests can also
+be executed manually as well::
 
     nosetests -v --with-coverage
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,39 +1,33 @@
 environment:
   global:
-    ADD_TEST_REQUIREMENTS: "1"
-
-    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    WITH_COMPILER: "cmd /E:ON /V:ON /C C:\\project\\run_with_cmd.cmd"
 
   matrix:
-
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
-
+    # Preinstalled Python versions
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_VERSION: "3.3.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_VERSION: "3.3.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
     # Python 2.6.6 is the only Python 2.6 version that can be installed
@@ -44,35 +38,37 @@ environment:
       PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "32"
 
-install:
-  - ECHO "Filesystem root:"
-  - ps: "ls \"C:/\""
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
 
-  - ECHO "Installed SDKs:"
-  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+build: false  # Not a C# project, build stuff at the test step instead.
+clone_folder: c:\\project
+
+install:
+  # First, download and install some files which help with the
+  # build/compile process
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/opalmer/pywincffi/appveyor/vcvars64.bat -OutFile "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
 
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
-  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
-  # Prepend newly installed Python to the PATH of this build (this cannot be
-  # done from inside the powershell script as it would require to restart
-  # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-
-  # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "pip install pip setuptools wheel --upgrade"
-
-  # Install the build dependencies of the project. If some dependencies contain
-  # compiled extensions and are not provided as pre-built wheel packages,
-  # pip will build them from source using the MSVC compiler matching the
-  # target Python version and architecture
-  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
-
-build: false  # Not a C# project, build stuff at the test step instead.
+  # Install some additional Python modules which will be required by
+  # the tests.  Oddly, there are somtimes issues in AppVeyor and/or Windows
+  # if these are installed from the setup.py.
+  - "%PYTHON%\\Scripts\\pip.exe install setuptools coverage wheel --upgrade"
 
 test_script:
   # Build the compiled extension and run the project tests
-  - "%CMD_IN_ENV% python setup.py install"
+  - ps: cd C:\\project
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\coverage.exe run setup.py test"
+  - "%PYTHON%\\Scripts\\coverage.exe report"
+
+after_test:
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - "pip install pip setuptools wheel --upgrade"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,6 @@ install:
   # build/compile process
   - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
   - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
-  - ps: Invoke-WebRequest https://raw.githubusercontent.com/opalmer/pywincffi/appveyor/vcvars64.bat -OutFile "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
 
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,77 @@
+environment:
+  global:
+    ADD_TEST_REQUIREMENTS: "1"
+
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "64"
+
+    # Python 2.6.6 is the only Python 2.6 version that can be installed
+    # without installing extra dependencies. See:
+    # https://github.com/ogrisel/python-appveyor-demo/issues/10
+    # https://github.com/pypa/pip/issues/2494
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+install:
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  # Build the compiled extension and run the project tests
+  - "%CMD_IN_ENV% python setup.py install"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires_extras = []
 if "READTHEDOCS" in os.environ:
     install_requires_extras = ["sphinx"]
 
-tests_require = ["nose", "coverage"]
+tests_require = ["nose", "coverage", "setuptools>=17.1"]
 
 py_major, py_minor = sys.version_info[0:2]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ if py_major == 2:
     tests_require.append("unittest2")
 
 if py_major == 2 and py_minor == 6:
+    # Later versions don't work with 2.6
     tests_require.append("mock==1.0.1")
 
 else:
@@ -39,9 +40,6 @@ else:
 
 if (py_major, py_minor) < (3, 4):
     install_requires_extras.append("enum34")
-
-if os.environ.get("ADD_TEST_REQUIREMENTS") == "1":
-    install_requires_extras += tests_require
 
 setup(
     name="pywincffi",

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,7 @@ else:
 if (py_major, py_minor) < (3, 4):
     install_requires_extras.append("enum34")
 
-
-# Running on buildbot
-if "BB_BUILDSLAVE" in os.environ:
+if os.environ.get("ADD_TEST_REQUIREMENTS") == "1":
     install_requires_extras += tests_require
 
 setup(


### PR DESCRIPTION
Instead of running buildbot, maintaining builders, etc.  pywincffi should use AppVeyor for testing.
