### PR TITLE
Fix Python 2.6 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,29 +6,29 @@ environment:
 
   matrix:
     # Preinstalled Python versions
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
+#    - PYTHON: "C:\\Python27"
+#      PYTHON_VERSION: "2.7.x"
+#      PYTHON_ARCH: "32"
+#
+#    - PYTHON: "C:\\Python27-x64"
+#      PYTHON_VERSION: "2.7.x"
+#      PYTHON_ARCH: "64"
+#
+#    - PYTHON: "C:\\Python33"
+#      PYTHON_VERSION: "3.3.x"
+#      PYTHON_ARCH: "32"
+#
+#    - PYTHON: "C:\\Python33-x64"
+#      PYTHON_VERSION: "3.3.x"
+#      PYTHON_ARCH: "64"
+#
+#    - PYTHON: "C:\\Python34"
+#      PYTHON_VERSION: "3.4.x"
+#      PYTHON_ARCH: "32"
+#
+#    - PYTHON: "C:\\Python34-x64"
+#      PYTHON_VERSION: "3.4.x"
+#      PYTHON_ARCH: "64"
 
     # Python 2.6.6 is the only Python 2.6 version that can be installed
     # without installing extra dependencies. See:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,16 +34,14 @@ environment:
     # without installing extra dependencies. See:
     # https://github.com/ogrisel/python-appveyor-demo/issues/10
     # https://github.com/pypa/pip/issues/2494
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.x"
       PYTHON_ARCH: "64"
 
-on_finish:
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,41 +6,40 @@ environment:
 
   matrix:
     # Preinstalled Python versions
-#    - PYTHON: "C:\\Python27"
-#      PYTHON_VERSION: "2.7.x"
-#      PYTHON_ARCH: "32"
-#
-#    - PYTHON: "C:\\Python27-x64"
-#      PYTHON_VERSION: "2.7.x"
-#      PYTHON_ARCH: "64"
-#
-#    - PYTHON: "C:\\Python33"
-#      PYTHON_VERSION: "3.3.x"
-#      PYTHON_ARCH: "32"
-#
-#    - PYTHON: "C:\\Python33-x64"
-#      PYTHON_VERSION: "3.3.x"
-#      PYTHON_ARCH: "64"
-#
-#    - PYTHON: "C:\\Python34"
-#      PYTHON_VERSION: "3.4.x"
-#      PYTHON_ARCH: "32"
-#
-#    - PYTHON: "C:\\Python34-x64"
-#      PYTHON_VERSION: "3.4.x"
-#      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
 
-    # Python 2.6.6 is the only Python 2.6 version that can be installed
-    # without installing extra dependencies. See:
-    # https://github.com/ogrisel/python-appveyor-demo/issues/10
-    # https://github.com/pypa/pip/issues/2494
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python26"
       PYTHON_VERSION: "2.6.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python26"
-      PYTHON_VERSION: "2.6.x"
-      PYTHON_ARCH: "64"
+    # Python 2.6 64-bit appers to be broken on AppVeyor.  However because
+    # we're testing 64-bit for all other versions, and 2.6 support is on
+    # the out anyway, we'll disable this for now.
+    # - PYTHON: "C:\\Python26"
+    #   PYTHON_VERSION: "2.6.x"
+    #   PYTHON_ARCH: "64"
 
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,9 @@ environment:
       PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "64"
 
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 


### PR DESCRIPTION
The old method of installing Python 2.6 seems to no longer work.  AppVeyor didn't have Python 2.6 initially which is why we had a script to perform the install for us instead.  However it would appear that AppVeyor now has Python 2.6 installed with at least the 32-bit version passing the build.  The 64-bit install of Python 2.6 seems to be missing a few libraries unfortunately so this PR also disables 64-bit testing for 2.6.   Considering we're testing 64-bit support with other interpreter versions and 2.6 is less and less common these days this shouldn't be an issue.  
