### PR TITLE
Fix Documentation sys.path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,12 @@ Python Windows Wrapper Using CFFI
     :target: https://ci.appveyor.com/project/opalmer/pywincffi/history
     :alt: build status
 
+.. image:: https://readthedocs.org/projects/pywincffi/badge/?version=latest
+    :target: http://pywincffi.readthedocs.org/en/latest/?badge=latest
+    :alt: documentation badge
 
-This library is a wrapper around some Windows functions using Python 
+
+This library is a wrapper around some Windows functions using Python
 and CFFI.  The repository was originally created to assist the Twisted
 project in moving away from pywin32 so installation does not require a compile
 step.
@@ -21,9 +25,9 @@ Development
 Python Version Support
 ----------------------
 
-This project supports Python 2.6 and up including 
+This project supports Python 2.6 and up including
 Python 3.  PRs, patches, tests etc that don't include
-support for both 2.x and 3.x will not be merged.  The 
+support for both 2.x and 3.x will not be merged.  The
 aim is also the support both major versions of Python within
 the same code base rather than rely on tools such as 2to3.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import ast
 import os
 import shutil
+import sys
 import subprocess
 from os.path import join, abspath, dirname
 
@@ -19,11 +20,16 @@ try:
 except NameError:
     WindowsError = OSError
 
+# Ensures certain non-cross platforms steps, such as building
+# some functions in testutil, don't run.
 os.environ["READTHEDOCS"] = "1"
 
 ROOT = abspath(join(dirname(abspath(__file__)), "..", ".."))
 DOC_MODULE_ROOT = join(ROOT, "docs", "source", "modules")
 MODULE_ROOT = join(ROOT, "pywincffi")
+
+# Required so we don't need to have pywincffi installed.
+sys.path.insert(0, ROOT)
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
This PR fixes the sys.path setup for the documentation which was incomplete in #22.  This also adds the documentation badge to `README.rst`
