### PR TITLE
Fix Lint Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4
-
-matrix:
-  exclude:
-    - python: 2.6
-      env: PYLINT=1
 
 env:
   - READTHEDOCS=1

--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=.git,build,docs,.ci
@@ -91,19 +88,12 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 #msg-template=
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter
@@ -279,10 +269,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -308,10 +294,6 @@ callbacks=cb_,_cb
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -4,9 +4,10 @@ Checks
 
 Provides functions that are responsible for internal type checks.
 """
-import enum
+
 from collections import namedtuple
 
+import enum
 from six import string_types
 
 from pywincffi.core.ffi import Library

--- a/pywincffi/core/testutil.py
+++ b/pywincffi/core/testutil.py
@@ -12,12 +12,13 @@ import sys
 from errno import ENOENT
 from os.path import isfile, isdir  # pylint: disable=ungrouped-imports
 
+from cffi import FFI
+
 if sys.version_info[0:2] != (2, 6):
+    # pylint: disable=wrong-import-order
     from unittest import TestCase as _TestCase
 else:
     from unittest2 import TestCase as _TestCase
-
-from cffi import FFI
 
 # To keep lint on non-windows platforms happy.
 try:

--- a/pywincffi/core/testutil.py
+++ b/pywincffi/core/testutil.py
@@ -10,14 +10,14 @@ import os
 import shutil
 import sys
 from errno import ENOENT
-from os.path import isfile, isdir
+from os.path import isfile, isdir  # pylint: disable=ungrouped-imports
+
+if sys.version_info[0:2] != (2, 6):
+    from unittest import TestCase as _TestCase
+else:
+    from unittest2 import TestCase as _TestCase
 
 from cffi import FFI
-
-if sys.version_info[0:2] == (2, 6):
-    from unittest2 import TestCase as _TestCase
-else:
-    from unittest import TestCase as _TestCase
 
 # To keep lint on non-windows platforms happy.
 try:
@@ -40,7 +40,8 @@ class TestCase(_TestCase):
     core test case just provides some extra functionality.
     """
     def setUp(self):
-        self.failIf(kernel32 is None, "kernel32 was never defined")
+        if kernel32 is None:
+            self.fail("kernel32 was never defined")
 
         # Always reset the last error to 0 between tests.  This
         # ensures that any error we intentionally throw in one


### PR DESCRIPTION
Recent versions of pylint have changed the way a couple of the checks work.  This PR fixes those problems in addition to removing Python 2.6 from the doc build (see 7bfa71b255316301b1950d144ad8dad5c80d440b)
