### PR TITLE
Implement handle_from_file()

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -154,7 +154,7 @@ attr-rgx=[a-z_][a-z0-9_]{2,30}$
 attr-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|logger|NoneType|Enums|kernel32|ffi)$
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|logger|NoneType|Enums|kernel32|ffi|FileType)$
 
 # Naming hint for constant names
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -272,7 +272,7 @@ ignored-classes=SQLObject
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent,HANDLE,OVERLAPPED,NON_ZERO,UTF8
+generated-members=REQUEST,acl_users,aq_parent,HANDLE,OVERLAPPED,NON_ZERO,UTF8,PYFILE
 
 
 [VARIABLES]

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -4,6 +4,8 @@
 //           RETURN_TYPE FunctionName(...
 //
 
+// Custom functions
+HANDLE handle_from_fd(int);
 
 // Processes
 HANDLE OpenProcess(DWORD, BOOL, DWORD);

--- a/pywincffi/core/cdefs/sources/main.c
+++ b/pywincffi/core/cdefs/sources/main.c
@@ -1,1 +1,6 @@
+#include <io.h>
 #include <windows.h>
+
+HANDLE handle_from_fd(int fd) {
+    return (HANDLE)_get_osfhandle(fd);
+}

--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -5,10 +5,12 @@ Checks
 Provides functions that are responsible for internal type checks.
 """
 
+import io
+import types
 from collections import namedtuple
 
 import enum
-from six import string_types
+from six import PY3, string_types
 
 from pywincffi.core.ffi import Library
 from pywincffi.core.logger import get_logger
@@ -22,7 +24,13 @@ NON_ZERO
 HANDLE
 UTF8
 OVERLAPPED
+PYFILE
 """.strip())
+
+if PY3:
+    FileType = io.IOBase
+else:
+    FileType = types.FileType  # pylint: disable=no-member
 
 # A mapping of value we can expect to get from `ffi.typeof` against
 # some known input enums.
@@ -153,6 +161,10 @@ def input_check(name, value, allowed_types=None, allowed_values=None):
             value.encode("utf-8")
         except (ValueError, AttributeError):
             raise InputError(name, value, allowed_types)
+
+    elif allowed_types is Enums.PYFILE:
+        if not isinstance(value, FileType):
+            raise InputError(name, value, "file type")
 
     else:
         if not isinstance(value, allowed_types):

--- a/pywincffi/core/lint.py
+++ b/pywincffi/core/lint.py
@@ -61,6 +61,11 @@ def register(linter):  # pylint: disable=unused-argument
     functions = set()
     with open(FUNCTIONS_HEADER, "r") as functions_file:
         for line in functions_file:
+            # special case that does not match the regex
+            if line.startswith("HANDLE handle_from_fd(int);"):
+                functions.add("handle_from_fd")
+                continue
+
             match = REGEX_FUNCTION.match(line)
             if match:
                 functions.add(match.group(1))

--- a/pywincffi/core/lint.py
+++ b/pywincffi/core/lint.py
@@ -28,8 +28,8 @@ SOURCES_DIR = join(
 CONSTANTS_HEADER = join(HEADERS_DIR, "constants.h")
 FUNCTIONS_HEADER = join(HEADERS_DIR, "functions.h")
 SOURCE_MAIN = join(SOURCES_DIR, "main.c")
-REGEX_FUNCTION = re.compile("^[A-Z]+ (.*)\(.*$")
-REGEX_CONSTANT = re.compile("^#define ([A-Z]*[_]*[A-Z]*[_]*[A-Z]*) ...$")
+REGEX_FUNCTION = re.compile(r"^[A-Z]+ (.*)\(.*$")
+REGEX_CONSTANT = re.compile(r"^#define ([A-Z]*[_]*[A-Z]*[_]*[A-Z]*) ...$")
 
 
 def transform(cls, constants=None, functions=None):

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -20,6 +20,31 @@ PeekNamedPipeResult = namedtuple(
 )
 
 
+def handle_from_file(python_file):
+    """
+    Given a standard Python file object produce a Windows
+    handle object that be be used in Windows function calls.
+
+    :param file python_file:
+        The Python file object to convert to a Windows handle.
+
+    :raises ValueError:
+        Raised if ``python_file`` is a valid file object
+        but is not open.
+
+    :return:
+        Returns a Windows handle object which is pointing at
+        the provided ``python_file`` object.
+    """
+    _, library = Library.load()
+    input_check("python_file", python_file, Enums.PYFILE)
+
+    # WARNING:
+    #   Be aware that passing in an invalid file descriptor
+    #   number can crash Python.
+    return library.handle_from_fd(python_file.fileno())
+
+
 def CreatePipe(nSize=0, lpPipeAttributes=None):
     """
     Creates an anonymous pipe and returns the read and write handles.


### PR DESCRIPTION
This PR implements the `handle_from_file()` function which can be used to produce a Windows handle from a file descriptor.  This was pulled out of #18 for the sake of clarity.
