### PR TITLE
Make handle_from_fd() more reliable and less likely to fail.

### DIFF
--- a/pywincffi/core/ffi.py
+++ b/pywincffi/core/ffi.py
@@ -19,7 +19,7 @@ from pywincffi.exceptions import ResourceNotFoundError
 try:
     WindowsError
 except NameError:
-    WindowsError = OSError
+    WindowsError = OSError  # pylint: disable=redefined-builtin
 
 
 logger = get_logger("core.ffi")

--- a/pywincffi/core/testutil.py
+++ b/pywincffi/core/testutil.py
@@ -24,7 +24,7 @@ else:
 try:
     WindowsError
 except NameError:
-    WindowsError = OSError
+    WindowsError = OSError  # pylint: disable=redefined-builtin
 
 # Load in our own kernel32 with the function(s) we need
 # so we don't have to rely on pywincffi.core

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -5,6 +5,7 @@ Files
 A module containing common Windows file functions.
 """
 
+import os
 from collections import namedtuple
 
 from six import integer_types
@@ -28,10 +29,6 @@ def handle_from_file(python_file):
     :param file python_file:
         The Python file object to convert to a Windows handle.
 
-    :raises ValueError:
-        Raised if ``python_file`` is a valid file object
-        but is not open.
-
     :return:
         Returns a Windows handle object which is pointing at
         the provided ``python_file`` object.
@@ -41,7 +38,9 @@ def handle_from_file(python_file):
 
     # WARNING:
     #   Be aware that passing in an invalid file descriptor
-    #   number can crash Python.
+    #   number can crash Python.  The input_check function
+    #   above should handle this for us by checking to
+    #   ensure the file descriptor is valid first.
     return library.handle_from_fd(python_file.fileno())
 
 

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -5,7 +5,6 @@ Files
 A module containing common Windows file functions.
 """
 
-import os
 from collections import namedtuple
 
 from six import integer_types

--- a/tests/test_kernel32/test_io.py
+++ b/tests/test_kernel32/test_io.py
@@ -180,7 +180,7 @@ class TestGetHandleFromFile(TestCase):
         test_file = os.fdopen(fd, "r")
         test_file.close()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InputError):
             handle_from_file(test_file)
 
     def test_opens_correct_file_handle(self):


### PR DESCRIPTION
`handle_from_fd()` has the potential side effect of crashing the interpreter if passed an invalid file descriptor.  While we can't fully prevent this if someone calls it directly we can sure that any file object passed into the Python side of the function is valid before we pass it to `handle_from_fd()` by checking the descriptor with `os.fstat` first.
