### PR TITLE
Simplify pywincffi.core.dist

### DIFF
--- a/.ci/appveyor/precompiled.ini
+++ b/.ci/appveyor/precompiled.ini
@@ -1,3 +1,0 @@
-[pywincffi]
-library=precompiled
-log_level=notset

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
 
 test_script:
   - ps: cd C:\\project
-  - "%WITH_COMPILER% %PYTHON%\\Scripts\\python.exe setup.py bdist_wheel"
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
   - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install ."
   - ps: cd ..
   - "%WITH_COMPILER% %PYTHON%\\Scripts\\nosetests.exe --with-coverage --cover-package pywincffi -v C:\\project\\tests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,20 +46,14 @@ install:
   # Install some additional Python modules which will be required by
   # the tests.  These can't be installed as part of the setup.py due
   # to file locking issues.
-  - "%PYTHON%\\Scripts\\pip.exe install virtualenv"
-  - "%PYTHON%\\Scripts\\virtualenv.exe C:\\virtualenv\\precompiled"
-  - "%PYTHON%\\Scripts\\virtualenv.exe C:\\virtualenv\\inline"
-  - "%WITH_COMPILER% C:\\virtualenv\\precompiled\\Scripts\\pip.exe install -r dev_requirements.txt --upgrade"
-  - "%WITH_COMPILER% C:\\virtualenv\\inline\\Scripts\\pip.exe install -r dev_requirements.txt --upgrade"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install -r dev_requirements.txt --upgrade"
 
 test_script:
-  # Precompiled test
   - ps: cd C:\\project
-  - "copy /Y .ci\\appveyor\\precompiled.ini %HOMEDRIVE%%HOMEPATH%\\pywincffi.ini"
-  - "%WITH_COMPILER% C:\\virtualenv\\precompiled\\Scripts\\python.exe setup.py bdist_wheel"
-  - "%WITH_COMPILER% C:\\virtualenv\\precompiled\\Scripts\\pip.exe install ."
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\python.exe setup.py bdist_wheel"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install ."
   - ps: cd ..
-  - "C:\\virtualenv\\precompiled\\Scripts\\nosetests.exe --with-coverage --cover-package pywincffi -v C:\\project\\tests"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\nosetests.exe --with-coverage --cover-package pywincffi -v C:\\project\\tests"
 
 
 artifacts:

--- a/pywincffi/core/config.py
+++ b/pywincffi/core/config.py
@@ -85,25 +85,4 @@ class Configuration(RawConfigParser):
 
         return self.LOGGER_LEVEL_MAPPINGS[level]
 
-    def tempdir(self):
-        """
-        Returns the directory which :class:`cffi.FFI` should use
-        to store temporary files.
-        """
-        entry = self.get("pywincffi", "tempdir")
-
-        try:
-            path = entry.format(tempdir=tempfile.gettempdir())
-        except KeyError as error:
-            raise ConfigurationError(
-                "Unknown key %r in pywincffi.tempdir" % error.args[0])
-
-        try:
-            os.makedirs(path)
-        except (OSError, IOError, WindowsError) as error:
-            if error.errno != EEXIST:
-                raise
-
-        return path
-
 config = Configuration()  # pylint: disable=invalid-name

--- a/pywincffi/core/config.py
+++ b/pywincffi/core/config.py
@@ -10,9 +10,6 @@ current working directory or the current users's home directory.
 """
 
 import logging
-import os
-import tempfile
-from errno import EEXIST
 from os.path import join, expanduser
 
 try:

--- a/pywincffi/core/config.py
+++ b/pywincffi/core/config.py
@@ -71,13 +71,6 @@ class Configuration(RawConfigParser):
 
         self.read(self.FILES)
 
-    def precompiled(self):
-        """
-        Returns True if the configuration states that we should be using
-        the precompiled library rather than trying to compile inline.
-        """
-        return self.get("pywincffi", "library") == "precompiled"
-
     def logging_level(self):
         """
         Returns the logging level that the configuration currently

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -263,5 +263,3 @@ def load():
         Module.cache = Module(_compile(_ffi()), "compiled")
 
     return Module.cache
-
-

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -33,13 +33,13 @@ ExtensionFileLoader = None  # pylint: disable=invalid-name
 try:
     # pylint: disable=wrong-import-order,wrong-import-position
     from importlib.machinery import ExtensionFileLoader
-except ImportError:
+except ImportError:  # pragma: no cover
     import imp  # pylint: disable=wrong-import-position,wrong-import-order
 
 
 try:
     WindowsError
-except NameError:
+except NameError:  # pragma: no cover
     WindowsError = OSError  # pylint: disable=redefined-builtin
 
 __all__ = ("load", )
@@ -116,10 +116,10 @@ def _import_path(path, module_name=None):
         loader = ExtensionFileLoader(module_name, path)
         return loader.load_module(module_name)
 
-    elif imp is not None:
+    elif imp is not None:  # pragma: no cover
         return imp.load_dynamic(module_name, path)
 
-    else:
+    else:  # pragma: no cover
         raise NotImplementedError(
             "Neither `imp` or `ExtensionFileLoader` were imported")
 
@@ -142,7 +142,7 @@ def _read(*paths):
         except (OSError, IOError, WindowsError) as error:
             if error.errno == ENOENT:
                 raise ResourceNotFoundError("Failed to locate %s" % path)
-            raise
+            raise  # pragma: no cover
 
     return output
 

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -33,18 +33,19 @@ from cffi import FFI
 from pywincffi.core.logger import get_logger
 from pywincffi.exceptions import ResourceNotFoundError
 
-imp = None
-ExtensionFileLoader = None
+imp = None  # pylint: disable=invalid-name
+ExtensionFileLoader = None  # pylint: disable=invalid-name
 try:
-    # pylint: disable=wrong-import-order
+    # pylint: disable=wrong-import-order,wrong-import-position
     from importlib.machinery import ExtensionFileLoader
 except ImportError:
-    import imp
+    import imp  # pylint: disable=wrong-import-position,wrong-import-order
+
 
 try:
     WindowsError
 except NameError:
-    WindowsError = OSError
+    WindowsError = OSError  # pylint: disable=redefined-builtin
 
 __all__ = ("load", )
 
@@ -63,7 +64,7 @@ SOURCE_FILES = [
         "pywincffi", join("core", "cdefs", "sources", "main.c"))]
 
 
-class Module(object):
+class Module(object):  # pylint: disable=too-few-public-methods
     """
     Used and returned by :func:`load`.  This class stores information
     about a loaded module and is

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -14,205 +14,236 @@ The second is to facilitate a means of building a static
 library.  This is used by the setup.py during the install
 process to build and install pywincffi as well as a wheel
 for distribution.
-
-The reason for this setup is so that pywincffi can handle
-the underlying load process inline. This makes it easier to
-test as well as perform some additional testing/development
-on non-windows platforms.
 """
 
-from collections import namedtuple
+from __future__ import print_function
+
+import shutil
+import os
+import sys
+import tempfile
+import warnings
+from contextlib import contextmanager
+from errno import ENOENT
 from os.path import join, isfile
 from pkg_resources import resource_filename
 
 from cffi import FFI
 
-from pywincffi.core.config import config
 from pywincffi.core.logger import get_logger
 from pywincffi.exceptions import ResourceNotFoundError
 
+imp = None
+ExtensionFileLoader = None
+try:
+    # pylint: disable=wrong-import-order
+    from importlib.machinery import ExtensionFileLoader
+except ImportError:
+    import imp
+
+try:
+    WindowsError
+except NameError:
+    WindowsError = OSError
+
+__all__ = ("load", )
 
 logger = get_logger("core.dist")
-InlineModule = namedtuple("InlineModule", ("ffi", "lib"))
+
+MODULE_NAME = "_pywincffi"
+HEADER_FILES = [
+    resource_filename(
+        "pywincffi", join("core", "cdefs", "headers", "constants.h")),
+    resource_filename(
+        "pywincffi", join("core", "cdefs", "headers", "structs.h")),
+    resource_filename(
+        "pywincffi", join("core", "cdefs", "headers", "functions.h"))]
+SOURCE_FILES = [
+    resource_filename(
+        "pywincffi", join("core", "cdefs", "sources", "main.c"))]
 
 
-def get_filepath(root, filename):
+class Module(object):
     """
-    Returns the filepath to the requested header or source
-    file.
-
-    :param str root:
-        The root directory under ``pywincffi/core/cdefs``. 'headers'
-        for example would be a valid entry here.
-
-    :param str filename:
-        The name of the file you want to retrieve under ``root``.
-
-    :raises ResourceNotFoundError:
-        Raised if the function could not find the requested file.
+    Used and returned by :func:`load`.  This class stores information
+    about a loaded module and is
     """
-    logger.debug("get_filepath(%r, %r)", root, filename)
-    path = resource_filename(
-        "pywincffi", join("core", "cdefs", root, filename))
+    cache = None
 
-    if not isfile(path):
-        raise ResourceNotFoundError(
-            "Failed to locate %s/%s" % (root, filename))
+    def __init__(self, module, mode):
+        if self.cache is not None:
+            warnings.warn(
+                "Module() was instanced multiple times", RuntimeWarning)
 
-    return path
+        self.module = module
+        self.mode = mode
+        self.ffi = module.ffi
+        self.lib = module.lib
+
+    def __repr__(self):
+        return "%r (%s)" % (self.module, self.mode)
+
+    def __iter__(self):
+        """
+        Override the original __iter__ so tuple unpacking can be
+        used to pull out ffi and lib.  This will allow
+        """
+        yield self.ffi
+        yield self.lib
 
 
-class Distribution(object):
+@contextmanager
+def _silence(silence):  # pragma: no cover
     """
-    A class responsible for building, caching and returning
-    the built artifacts for :mod:`pywincffi`
+    The compile step tends to be noisy so this context manager will silent
+    the output.  It shouldn't be used to silence ``sys.stderr`` and should
+    be used to display data from ``sys.stdout`` if there are problems:
 
-    :ivar str MODULE_NAME:
-        The name of the module to pass to :meth:`FFI.set_source`. This
-        will eventually end up becoming the name of the underlying C-module
-        that is built.
-
-    :ivar tuple HEADERS:
-        A tuple containing all the headers used to build pywincffi.
-
-    :ivar tuple SOURCES:
-        A tuple containing all the C source files to build pywincffi.
-
-    :ivar tuple LIBRARIES:
-        A tuple of Windows library names that :meth:`FFI.verify` should
-        use.
+    >>> import sys, os
+    >>> with _silence(sys.stdout) as out_path:
+    ...     try:
+    ...         print("Foobar", file=sys.stdout)
+    ...         raise Exception("Some failure")
+    ...     except Exception:
+    ...         with open(out_path) as file_:
+    ...             print(file_.read(), file=sys.stderr)
+    ...         raise
+    ...     finally:
+    ...         os.remove(out_path)
     """
-    MODULE_NAME = "_pywincffi"
-    HEADERS = (
-        get_filepath("headers", "constants.h"),
-        get_filepath("headers", "structs.h"),
-        get_filepath("headers", "functions.h")
-    )
-    SOURCES = (get_filepath("sources", "main.c"), )
-    LIBRARIES = ("kernel32", )
+    silence_fd = silence.fileno()
 
-    # Attributes used internally by this class for caching.
-    _pywincffi = None
+    with os.fdopen(os.dup(silence_fd), "wb") as copied:
+        silence.flush()  # Flush library buffers that dup2 knows nothing about
 
-    @classmethod
-    def load_definitions(cls):
-        """
-        Reads in the headers and source files and produces
-        a tuple of strings with the results.
-
-        :rtype: tuple
-        :return:
-            Returns a tuple of strings containing the headers
-            and sources.
-        """
-        header = ""
-        source = ""
-
-        for path in cls.HEADERS:
-            logger.debug("Reading %s", path)
-            with open(path, "r") as file_:
-                header += file_.read()
-
-        for path in cls.SOURCES:
-            logger.debug("Reading %s", path)
-            with open(path, "r") as file_:
-                source += file_.read()
-
-        return header, source
-
-    @classmethod
-    def inline(cls):
-        """
-        Compiles pywincffi in inline mode.  This is mainly used when
-        doing development and is conditionally called by :meth:`load`
-        below.
-        """
-        logger.debug("Compiling inline to %s", config.tempdir())
-        header, source = cls.load_definitions()
-
-        ffi_class = FFI()
-        ffi_class.set_unicode(True)
-        ffi_class.cdef(header)
-        cls._pywincffi = InlineModule(
-            ffi=ffi_class,
-            lib=ffi_class.verify(
-                source, libraries=cls.LIBRARIES, tmpdir=config.tempdir())
-        )
-
-        return cls._pywincffi.ffi, cls._pywincffi.lib
-
-    @classmethod
-    def out_of_line(cls, compile_=True):
-        """
-        Compiles pywincffi in out of line mode.  This is used to create a
-        distribution of pywcinffi and more specifically is used by
-        ``setup.py``.
-
-        :param bool compile_:
-            If True then perform the compile step as well.  By default calling
-            this executes :func:`FFI.compile` which will build the underlying
-            library.
-
-        :returns:
-            Returns a tuple of elements containing an instance of
-            :class:`FFI` and a string pointing at the module that
-            was built.
-        """
-        header, source = cls.load_definitions()
-
-        ffi_class = FFI()
-        ffi_class.set_unicode(True)
-        ffi_class.set_source(cls.MODULE_NAME, source)
-        ffi_class.cdef(header)
-
-        built_path = None
-        if compile_:
-            tempdir = config.tempdir()
-            logger.debug("Compiling out of line to %s", tempdir)
-            built_path = ffi_class.compile(tmpdir=tempdir)
-
-        return ffi_class, built_path
-
-    @classmethod
-    def load(cls):
-        """
-        Responsible for loading an instance of :class:`FFI` and
-        the underlying compiled library.  This class method will
-        have different behaviors depending on a few factors:
-
-            * If ``PYWINCFFI_DEV`` is set to ``1`` in the environment
-              we call and return :meth:`inline`.
-            * Attempt to load :mod:`pywincffi._pywincffi`.  If we can,
-              instance :class:`FFI` and return this plus
-              :mod:`pywincffi._pywincffi`.
-            * If :mod:`pywincffi._pywincffi` can't be loaded, call
-              :meth:`inline` to try and compile the module instead.
-        """
-        # Return the pre-cached library if we've
-        # already loaded one below.
-        if cls._pywincffi is not None:
-            return cls._pywincffi.ffi, cls._pywincffi.lib
-
-        if not config.precompiled():
-            return cls.inline()
+        fd, path = tempfile.mkstemp()
+        os.dup2(fd, silence_fd)
 
         try:
-            import _pywincffi
-            cls._pywincffi = _pywincffi
-            return cls._pywincffi.ffi, cls._pywincffi.lib
-
-        except ImportError:
-            logger.warning(
-                "Failed to load _pywincffi, attempting to compile inline.")
-            return cls.inline()
+            yield path
+        finally:
+            silence.flush()
+            os.dup2(copied.fileno(), silence_fd)
+            os.fsync(fd)
+            os.close(fd)
 
 
-def ffi():
+def _import_path(path, module_name=None):
     """
-    Called by the setup.py to get an out of line instance of :class:`FFI`
-    which can be used to build pywincffi.
+    Function which imports ``path`` and returns it as a module.  This is
+    meant to import pyd files produced by :meth:`Distribution._build` in
+    a Python 2/3 agnostic fashion.
+
+    :param str path:
+        The path to the file to import
+
+    :keyword str module_name:
+        Optional name of the module being imported.  By default
+        this will use ``Module.name`` if no value is provided.
+
+    :raises ResourceNotFoundError:
+        Raised if ``path`` does not exist.
     """
-    return Distribution.out_of_line(compile_=False)[0]
+    if module_name is None:  # pragma: no cover
+        module_name = MODULE_NAME
+
+    logger.debug("_import_path(%r, module_name=%r)", path, module_name)
+
+    if not isfile(path):
+        raise ResourceNotFoundError("Module path %r does not exist" % path)
+
+    elif ExtensionFileLoader is not None:
+        loader = ExtensionFileLoader(module_name, path)
+        return loader.load_module(module_name)
+
+    elif imp is not None:
+        return imp.load_dynamic(module_name, path)
+
+    else:
+        raise NotImplementedError(
+            "Neither `imp` or `ExtensionFileLoader` were imported")
+
+
+def _read(*paths):
+    """
+    Iterates over ``files`` and produces string which combines all inputs
+    into a single string.
+
+    :raises ResourceNotFoundError:
+        Raised if one of the files in ``files`` is missing.
+    """
+    logger.debug("_read(%r)", paths)
+
+    output = ""
+    for path in paths:
+        try:
+            with open(path, "r") as file_:
+                output += file_.read()
+        except (OSError, IOError, WindowsError) as error:
+            if error.errno == ENOENT:
+                raise ResourceNotFoundError("Failed to locate %s" % path)
+            raise
+
+    return output
+
+
+def _ffi():
+    """
+    Returns an instance of :class:`FFI` without compiling
+    the module.  This function is used internally but also
+    as an entrypoint in the setup.py for `cffi_modules`.
+    """
+    logger.debug("_ffi()")
+    header = _read(*HEADER_FILES)
+    source = _read(*SOURCE_FILES)
+
+    ffi = FFI()
+    ffi.set_unicode(True)
+    ffi.set_source(MODULE_NAME, source)
+    ffi.cdef(header)
+
+    return ffi
+
+
+def _compile(ffi, tmpdir=None):
+    """
+    Performs the compile step, loads the resulting module and then
+    return it.
+
+    :param cffi.FFI ffi:
+        An instance of :class:`FFI` which you wish to compile and load
+        the resulting module for.
+
+    :keyword str tmpdir:
+        The path to compile the module to.  By default this will be
+        constructed using ``tempfile.mkdtemp(prefix="pywincffi-")``.
+
+    :returns:
+        Returns the module built by compiling the ``ffi`` object.
+    """
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp(prefix="pywincffi-")
+
+    logger.debug("_compile(%r, tmpdir=%r)", ffi, tmpdir)
+
+    with _silence(sys.stdout) as out_path:
+        try:
+            pyd_path = ffi.compile(tmpdir=tmpdir)
+
+        except Exception:  # pragma: no cover
+            with open(out_path) as file_:
+                print(file_.read(), file=sys.stderr)
+            raise
+
+    os.remove(out_path)
+    module = _import_path(pyd_path)
+
+    # Try to cleanup the temp directory that was created
+    # for compiling the module.  In most cases this will
+    # remove everything but the built .pyd file.
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return module
 
 
 def load():
@@ -220,6 +251,17 @@ def load():
     The main function used by pywincffi to load an instance of
     :class:`FFI` and the underlying build library.
     """
-    return Distribution.load()
+    if Module.cache is not None:
+        return Module.cache
 
-__all__ = ("ffi", "load")
+    logger.debug("load()")
+    try:
+        import _pywincffi
+        Module.cache = Module(_pywincffi, "prebuilt")
+
+    except ImportError:
+        Module.cache = Module(_compile(_ffi()), "compiled")
+
+    return Module.cache
+
+

--- a/pywincffi/core/pywincffi.ini
+++ b/pywincffi/core/pywincffi.ini
@@ -1,8 +1,4 @@
 [pywincffi]
-; The directory used by pywincffi for temporoary files such
-; as those produced at compile time.
-tempdir={tempdir}\\pywincffi
-
 ; Controls the logging level for pywincffi. Valid levels are:
 ;   notset
 ;   debug

--- a/pywincffi/core/pywincffi.ini
+++ b/pywincffi/core/pywincffi.ini
@@ -1,13 +1,4 @@
 [pywincffi]
-; The preferred mode for pywincffi.core.dist.load to operation in.
-; Valid options are:
-;   precompiled - Import the prebuilt library, fail if we can't import it.
-;   inline - Build the module inline rather than trying to load from disk.  This
-;            mode is meant for development and testing but could also be used
-;            to work around issues with the precompiled library (assuming the
-;            local system can support this).
-library=precompiled
-
 ; The directory used by pywincffi for temporoary files such
 ; as those produced at compile time.
 tempdir={tempdir}\\pywincffi

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_keywords = dict(
 # not work.
 if os.name == "nt":
     setup_keywords.update(
-        cffi_modules=["pywincffi/core/dist.py:ffi"]
+        cffi_modules=["pywincffi/core/dist.py:_ffi"]
     )
 
 setup(**setup_keywords)

--- a/tests/test_core/test_checks.py
+++ b/tests/test_core/test_checks.py
@@ -4,48 +4,13 @@ import tempfile
 import types
 
 from six import PY3, PY2
-from mock import patch
-from cffi import FFI
 
 from pywincffi.core import dist
 from pywincffi.core.checks import (
     INPUT_CHECK_MAPPINGS, FileType, CheckMapping, Enums,
-    input_check, error_check)
-from pywincffi.core.config import config
+    input_check)
 from pywincffi.core.testutil import TestCase
-from pywincffi.exceptions import WindowsAPIError, InputError
-
-
-# TODO: rewrite this so it works for both precompiled and inline modules
-class TestCheckErrorCode(TestCase):
-    """
-    Tests for :func:`pywincffi.core.ffi.check_error_code`
-    """
-    LIBRARY_MODE = "inline"
-
-    def setUp(self):
-        super(TestCheckErrorCode, self).setUp()
-        if config.precompiled():
-            self.skipTest("inline only")
-
-        # TODO: build inline here, replace dist.load()
-
-    def test_default_code_does_match_expected(self):
-        with patch.object(FFI, "getwinerror", return_value=(0, "GTG")):
-            error_check("Foobar")
-
-    def test_default_code_does_not_match_expected(self):
-        with patch.object(FFI, "getwinerror", return_value=(0, "NGTG")):
-            with self.assertRaises(WindowsAPIError):
-                error_check("Foobar", expected=2)
-
-    def test_non_zero(self):
-        with patch.object(FFI, "getwinerror", return_value=(1, "NGTG")):
-            error_check("Foobar", expected=Enums.NON_ZERO)
-
-    def test_non_zero_success(self):
-        with patch.object(FFI, "getwinerror", return_value=(0, "NGTG")):
-            error_check("Foobar", code=1, expected=Enums.NON_ZERO)
+from pywincffi.exceptions import InputError
 
 
 class TestTypeCheckFailure(TestCase):

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -2,9 +2,8 @@ from __future__ import print_function
 
 import logging
 import os
-import tempfile
 from textwrap import dedent
-from os.path import isfile, join, expanduser, isdir
+from os.path import isfile, join, expanduser
 
 from mock import patch
 from six import PY3

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -112,21 +112,6 @@ class TestLoad(TestCase):
             self.assertEqual(config.getint("pywincffi", "log_level"), -1)
 
 
-class TestPrecompiled(TestCase):
-    """
-    Tests for ``pywincffi.core.config.Configuration.precompiled``
-    """
-    def test_precompiled(self):
-        config = Configuration()
-        config.set("pywincffi", "library", "precompiled")
-        self.assertTrue(config.precompiled())
-
-    def test_not_precompiled(self):
-        config = Configuration()
-        config.set("pywincffi", "library", "foo")
-        self.assertFalse(config.precompiled())
-
-
 class TestLoggingLevel(TestCase):
     """
     Tests for ``pywincffi.core.config.Configuration.logging_level``
@@ -143,35 +128,3 @@ class TestLoggingLevel(TestCase):
             config = Configuration()
             config.set("pywincffi", "log_level", key)
             self.assertEqual(config.logging_level(), value)
-
-
-class TestTempdir(TestCase):
-    """
-    Tests for ``pywincffi.core.config.Configuration.tempdir``
-    """
-    def test_unknown_key(self):
-        config = Configuration()
-        config.set("pywincffi", "tempdir", "{foobar}")
-
-        with self.assertRaises(ConfigurationError):
-            config.tempdir()
-
-    def test_creates_directory(self):
-        tempdir = join(self.tempdir(), "pywincffi")
-        config = Configuration()
-        config.set("pywincffi", "tempdir", tempdir)
-        self.assertFalse(isdir(tempdir))
-        config.tempdir()
-        self.assertTrue(isdir(tempdir))
-        config.tempdir()  # calling again should not raise exception
-
-    def test_return_value(self):
-        tempdir = join(self.tempdir(), "pywincffi")
-        config = Configuration()
-        config.set("pywincffi", "tempdir", tempdir)
-        self.assertEqual(tempdir, config.tempdir())
-
-    def test_tempdir_substitution(self):
-        config = Configuration()
-        config.set("pywincffi", "tempdir", "{tempdir}")
-        self.assertEqual(tempfile.gettempdir(), config.tempdir())

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -12,8 +12,8 @@ from cffi import FFI
 from mock import Mock, patch
 
 from pywincffi.core.dist import (
-    MODULE_NAME, HEADER_FILES, SOURCE_FILES, Module, _import_path, _silence,
-    _ffi, _compile, _read, load)
+    MODULE_NAME, HEADER_FILES, SOURCE_FILES, Module, _import_path, _ffi,
+    _compile, _read, load)
 from pywincffi.core.testutil import TestCase
 from pywincffi.exceptions import ResourceNotFoundError
 
@@ -82,17 +82,7 @@ class TestImportPath(TestCase):
         ffi.cdef(self.header)
         tmpdir = tempfile.mkdtemp(prefix="pywincffi-tests-")
         self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
-
-        with _silence(sys.stdout) as out_path:
-            self.addCleanup(os.remove, out_path)
-
-            try:
-                return self.module_name, ffi.compile(tmpdir=tmpdir)
-
-            except Exception:
-                with open(out_path) as file_:
-                    print(file_.read(), file=sys.stderr)
-                raise
+        return self.module_name, ffi.compile(tmpdir=tmpdir)
 
     def test_invalid_path(self):
         with self.assertRaises(ResourceNotFoundError):

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import binascii
 import os
 import shutil

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -69,7 +69,8 @@ class TestImportPath(TestCase):
     """Tests for :func:`pywincffi.core.dist._import_path`"""
     def setUp(self):
         super(TestImportPath, self).setUp()
-        self.module_name = "m" + binascii.b2a_hex(os.urandom(6)).decode("utf-8")
+        self.module_name = \
+            "m" + binascii.b2a_hex(os.urandom(6)).decode("utf-8")
         self.header = "int add(int, int);"
         self.source = "int add(int a, int b) {return a + b;}"
 
@@ -234,4 +235,3 @@ class TestLoad(TestCase):
         sys.modules["_pywincffi"] = None
         loaded = load()
         self.assertEqual(loaded.mode, "compiled")
-

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -39,6 +39,11 @@ class TestModule(TestCase):
         super(TestModule, self).setUp()
         Module.cache = None
 
+    def tearDown(self):
+        super(TestModule, self).tearDown()
+        Module.cache = None
+        sys.modules.pop("_pywincffi", None)
+
     def test_cache_default(self):
         self.assertIsNone(Module.cache)
 
@@ -149,6 +154,8 @@ class TestCompile(TestCase):
         super(TestCompile, self).tearDown()
         HEADER_FILES[:] = self.header_files
         SOURCE_FILES[:] = self.source_files
+        Module.cache = None
+        sys.modules.pop("_pywincffi", None)
 
     def test_compile(self):
         # Create fake header
@@ -196,18 +203,10 @@ class TestCompile(TestCase):
 
 class TestLoad(TestCase):
     """Tests for :func:`pywincffi.core.dist.load`"""
-    def setUp(self):
-        super(TestLoad, self).setUp()
-        if "_pywincffi" in sys.modules:
-            self.addCleanup(
-                sys.modules.__setitem__,
-                "_pywincffi", sys.modules.pop("_pywincffi"))
-        else:
-            self.addCleanup(sys.modules.pop, "_pywincffi")
-
     def tearDown(self):
         super(TestLoad, self).tearDown()
         Module.cache = None
+        sys.modules.pop("_pywincffi", None)
 
     def test_cache(self):
         cached = object()

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -74,7 +74,7 @@ class TestImportPath(TestCase):
         self.header = "int add(int, int);"
         self.source = "int add(int a, int b) {return a + b;}"
 
-    def build(self, name=None):
+    def build(self):
         ffi = FFI()
         ffi.set_source(self.module_name, self.source)
         ffi.cdef(self.header)

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -1,328 +1,237 @@
-import imp
+import binascii
 import os
-import platform
+import shutil
 import sys
-import types
-from os.path import isfile, dirname, basename, join
+import tempfile
+import warnings
+from os.path import isfile, dirname
 
 from cffi import FFI
-from mock import patch
+from mock import Mock, patch
 
-from pywincffi.core.config import config
 from pywincffi.core.dist import (
-    __all__, Distribution, InlineModule, get_filepath, ffi, load)
+    MODULE_NAME, HEADER_FILES, SOURCE_FILES, Module, _import_path, _silence,
+    _ffi, _compile, _read, load)
 from pywincffi.core.testutil import TestCase
 from pywincffi.exceptions import ResourceNotFoundError
 
 
-try:
-    # pylint: disable=wrong-import-order
-    from importlib.machinery import ExtensionFileLoader
+class TestConstants(TestCase):
+    def test_module_name(self):
+        self.assertEqual(MODULE_NAME, "_pywincffi")
 
-    def import_module(module_name, path):
-        loader = ExtensionFileLoader(module_name, path)
-        return loader.load_module(module_name)
+    def test_header_files_exist(self):
+        for path in HEADER_FILES:
+            self.assertTrue(isfile(path))
 
-    def new_module(name):
-        return types.ModuleType(name)
-
-except ImportError:
-    def import_module(module_name, path):
-        return imp.load_dynamic(module_name, path)
-
-    def new_module(name):
-        return imp.new_module(name)
+    def test_source_files_exist(self):
+        for path in SOURCE_FILES:
+            self.assertTrue(isfile(path))
 
 
-class TestGetFilepath(TestCase):
+class TestModule(TestCase):
     """
-    Tests for ``pywincffi.core.get_filepath``
+    Tests for :class:`pywincffi.core.dist.Module`
     """
-    def test_headers(self):
-        for path in Distribution.HEADERS:
-            root = dirname(path)
-            filename = basename(path)
-            self.assertTrue(isfile(get_filepath(root, filename)))
-
-    def test_sources(self):
-        for path in Distribution.SOURCES:
-            root = dirname(path)
-            filename = basename(path)
-            self.assertTrue(isfile(get_filepath(root, filename)))
-
-    def test_file_does_not_exist(self):
-        with self.assertRaises(ResourceNotFoundError):
-            get_filepath("", "")
-
-
-class TestDistributionHeaders(TestCase):
-    """
-    Tests for ``pywincffi.core.dist.Distribution.HEADERS``
-    """
-    def test_variable_type(self):
-        self.assertIsInstance(Distribution.HEADERS, tuple)
-
-    def test_value_types(self):
-        for value in Distribution.HEADERS:
-            self.assertIsInstance(value, str)
-
-    def test_is_file(self):
-        for value in Distribution.HEADERS:
-            self.assertTrue(isfile(value))
-
-
-class TestDistributionSources(TestCase):
-    """
-    Tests for ``pywincffi.core.dist.Distribution.SOURCES``
-    """
-    def test_variable_type(self):
-        self.assertIsInstance(Distribution.SOURCES, tuple)
-
-    def test_value_types(self):
-        for value in Distribution.SOURCES:
-            self.assertIsInstance(value, str)
-
-    def test_is_file(self):
-        for value in Distribution.SOURCES:
-            self.assertTrue(isfile(value))
-
-
-class TestDistributionLoadDefinitions(TestCase):
-    def test_header(self):
-        expected = ""
-        for path in Distribution.HEADERS:
-            with open(path, "r") as file_:
-                expected += file_.read()
-
-        self.assertEqual(expected, Distribution.load_definitions()[0])
-
-    def test_source(self):
-        expected = ""
-        for path in Distribution.SOURCES:
-            with open(path, "r") as file_:
-                expected += file_.read()
-
-        self.assertEqual(expected, Distribution.load_definitions()[1])
-
-
-class TestDistributionLoadBaseTest(TestCase):
-    HEADERS = None
-    SOURCES = None
-    count = 0
-
     def setUp(self):
-        super(TestDistributionLoadBaseTest, self).setUp()
+        super(TestModule, self).setUp()
+        Module.cache = None
 
-        if hasattr(sys, "maxsize"):
-            if sys.maxsize > 2**32:
-                python_arch = 64
-            else:
-                python_arch = 32
-        else:
-            # Python < 2.6, not as accurate as the above
-            if platform.architecture()[0] == "64bits":
-                python_arch = 64
-            else:
-                python_arch = 32
+    def test_cache_default(self):
+        self.assertIsNone(Module.cache)
 
-        # These tests are broken for some reason.  The ability to
-        # genera inline/out-of-line modules is already tested however
-        # so there's something else going on here.
-        # TODO: fix this...
-        if (python_arch == 64 and
-                sys.version_info[0] == 3 and os.environ.get("APPVEYOR")):
-            self.skipTest(
-                "This test does not currently support Python 3 64-bit on "
-                "Appveyor")
+    def test_double_cache_produces_warning(self):
+        Module.cache = ""
 
-        # Capture the existing values
-        self._pywincffi = Distribution._pywincffi
-        self._headers = Distribution.HEADERS
-        self._sources = Distribution.SOURCES
-        self.count += 1
-        self.function_name = "add%s" % self.count
-        self._pywincffi_module = sys.modules.pop(
-            Distribution.MODULE_NAME, None)
+        with warnings.catch_warnings(record=True) as caught:
+            Module(Mock(ffi=None, lib=None), None)
 
-        headers = self.HEADERS
-        if self.HEADERS is None:
-            headers = self.generate_headers()
+        warning = caught.pop(0)
+        self.assertIs(warning.category, RuntimeWarning)
+        self.assertEqual(
+            warning.message.args[0], "Module() was instanced multiple times")
 
-        sources = self.SOURCES
-        if self.SOURCES is None:
-            sources = self.generate_sources()
+    def test_attributes(self):
+        m = Module(Mock(ffi=1, lib=2), "foo")
+        self.assertEqual(m.ffi, 1)
+        self.assertEqual(m.lib, 2)
+        self.assertEqual(m.mode, "foo")
 
-        # Reset the to something we can test with
-        Distribution._pywincffi = None
-        Distribution.HEADERS = headers
-        Distribution.SOURCES = sources
+    def test_tuple_unpacking(self):
+        m = Module(Mock(ffi=1, lib=2), "foo")
+        unpacked = tuple(m)
+        self.assertEqual(len(unpacked), 2)
+        self.assertEqual(unpacked[0], 1)
+        self.assertEqual(unpacked[1], 2)
+
+
+class TestImportPath(TestCase):
+    """Tests for :func:`pywincffi.core.dist._import_path`"""
+    def setUp(self):
+        super(TestImportPath, self).setUp()
+        self.module_name = "m" + binascii.b2a_hex(os.urandom(6)).decode("utf-8")
+        self.header = "int add(int, int);"
+        self.source = "int add(int a, int b) {return a + b;}"
+
+    def build(self, name=None):
+        ffi = FFI()
+        ffi.set_source(self.module_name, self.source)
+        ffi.cdef(self.header)
+        tmpdir = tempfile.mkdtemp(prefix="pywincffi-tests-")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+
+        with _silence(sys.stdout) as out_path:
+            self.addCleanup(os.remove, out_path)
+
+            try:
+                return self.module_name, ffi.compile(tmpdir=tmpdir)
+
+            except Exception:
+                with open(out_path) as file_:
+                    print(file_.read(), file=sys.stderr)
+                raise
+
+    def test_invalid_path(self):
+        with self.assertRaises(ResourceNotFoundError):
+            _import_path("")
+
+    def test_imported_module(self):
+        name, path = self.build()
+        module = _import_path(path, module_name=name)
+        self.assertTrue(hasattr(module, "lib"))
+        self.assertTrue(hasattr(module.lib, "add"))
+        self.assertEqual(module.lib.add(1, 2), 3)
+
+
+class TestRead(TestCase):
+    """Tests for :func:`pywincffi.core.dist._read`"""
+    def test_loads_files(self):
+        temp_files = []
+        expected_output = ""
+        for i in range(10):
+            expected_output += str(i)
+            fd, path = tempfile.mkstemp()
+            self.addCleanup(os.remove, path)
+            with os.fdopen(fd, "w") as file_:
+                file_.write(str(i))
+            temp_files.append(path)
+
+        self.assertEqual(_read(*temp_files), expected_output)
+
+    def test_raises_resource_not_found_error(self):
+        with self.assertRaises(ResourceNotFoundError):
+            _read("")
+
+
+class TestFFI(TestCase):
+    """Tests for :func:`pywincffi.core.dist._ffi`"""
+    def test_sets_unicode(self):
+        with patch.object(FFI, "set_unicode") as mocked_set_unicode:
+            _ffi()
+
+        mocked_set_unicode.assert_called_once_with(True)
+
+    def test_set_source(self):
+        with patch.object(FFI, "set_source") as mocked_set_source:
+            _ffi()
+
+        mocked_set_source.assert_called_once_with(
+            MODULE_NAME, _read(*SOURCE_FILES))
+
+    def test_cdef(self):
+        with patch.object(FFI, "cdef") as mocked_cdef:
+            _ffi()
+
+        mocked_cdef.assert_called_with(_read(*HEADER_FILES))
+
+
+class TestCompile(TestCase):
+    """Tests for :func:`pywincffi.core.dist._compile`"""
+    def setUp(self):
+        super(TestCompile, self).setUp()
+        self.header_files = HEADER_FILES[:]
+        self.source_files = SOURCE_FILES[:]
 
     def tearDown(self):
-        super(TestDistributionLoadBaseTest, self).tearDown()
-        Distribution._pywincffi = self._pywincffi
-        Distribution.HEADERS = self._headers
-        Distribution.SOURCES = self._sources
+        super(TestCompile, self).tearDown()
+        HEADER_FILES[:] = self.header_files
+        SOURCE_FILES[:] = self.source_files
 
-        if self._pywincffi_module is not None:
-            sys.modules.update(_pywincffi=self._pywincffi_module)
+    def test_compile(self):
+        # Create fake header
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        HEADER_FILES[:] = [path]
 
-    def generate_headers(self):
-        path = self.tempfile("int %s(int);" % self.function_name)
-        return path,
+        with os.fdopen(fd, "w") as header:
+            header.write("int add(int, int);")
 
-    def generate_sources(self):
-        path = self.tempfile(
-            "int %s(int value) {return value + 1;}" % self.function_name)
-        return path,
+        # Create fake source
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        SOURCE_FILES[:] = [path]
+        with os.fdopen(fd, "w") as source:
+            source.write("int add(int a, int b) {return a + b;}")
 
+        ffi = _ffi()
+        module = _compile(ffi)
+        self.assertEqual(module.lib.add(1, 2), 3)
 
-class TestDistributionInline(TestDistributionLoadBaseTest):
-    """
-    Tests for :meth:`pywincffi.core.dist.Distribution.inline`
-    """
-    def configure(self, config_):
-        super(TestDistributionInline, self).configure(config_)
-        config.set("pywincffi", "library", "inline")
-        config.set("pywincffi", "tempdir", self.tempdir())
+    def test_compile_uses_provided_tempdir(self):
+        # Create fake header
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        HEADER_FILES[:] = [path]
 
-    def test_sets_unicode(self):
-        ffi_, _ = Distribution.inline()
-        with self.assertRaises(ValueError):
-            ffi_.set_unicode(True)
+        with os.fdopen(fd, "w") as header:
+            header.write("int add(int, int);")
 
-    def test_ffi_type(self):
-        ffi_, _ = Distribution.inline()
-        self.assertIsInstance(ffi_, FFI)
+        # Create fake source
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        SOURCE_FILES[:] = [path]
+        with os.fdopen(fd, "w") as source:
+            source.write("int add(int a, int b) {return a + b;}")
 
-    def test_caches_inline_module(self):
-        Distribution.inline()
-        self.assertIsInstance(Distribution._pywincffi, InlineModule)
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
 
-    def test_calling_inline_resets_cache(self):
-        Distribution.inline()
-        module = Distribution._pywincffi
-        Distribution.inline()
-        self.assertIsNot(Distribution._pywincffi, module)
-
-    def test_inline_produces_function(self):
-        _, library = Distribution.inline()
-        func = getattr(library, self.function_name)
-        self.assertEqual(func(1), 2)
+        ffi = _ffi()
+        module = _compile(ffi, tmpdir=tmpdir)
+        self.assertEqual(dirname(module.__file__), tmpdir)
 
 
-class TestDistributionOutOfLine(TestDistributionLoadBaseTest):
-    """
-    Tests for :meth:`pywincffi.core.dist.Distribution.out_of_line`
-    """
-    def configure(self, config_):
-        super(TestDistributionOutOfLine, self).configure(config_)
-        config.set("pywincffi", "library", "precompiled")
-        config.set("pywincffi", "tempdir", self.tempdir())
+class TestLoad(TestCase):
+    """Tests for :func:`pywincffi.core.dist.load`"""
+    def setUp(self):
+        super(TestLoad, self).setUp()
+        if "_pywincffi" in sys.modules:
+            self.addCleanup(
+                sys.modules.__setitem__,
+                "_pywincffi", sys.modules.pop("_pywincffi"))
+        else:
+            self.addCleanup(sys.modules.pop, "_pywincffi")
 
-    def test_sets_unicode(self):
-        ffi_, _ = Distribution.out_of_line()
+    def tearDown(self):
+        super(TestLoad, self).tearDown()
+        Module.cache = None
 
-        with self.assertRaises(ValueError):
-            ffi_.set_unicode(True)
+    def test_cache(self):
+        cached = object()
+        Module.cache = cached
+        self.assertIs(load(), cached)
 
-    def test_ffi_type(self):
-        ffi_, _ = Distribution.out_of_line()
-        self.assertIsInstance(ffi_, FFI)
+    def test_prebuilt(self):
+        fake_module = Mock(ffi=1, lib=2)
+        sys.modules["_pywincffi"] = fake_module
+        loaded = load()
+        self.assertEqual(loaded.mode, "prebuilt")
 
-    def test_library_path(self):
-        _, path = Distribution.out_of_line()
-        self.assertTrue(isfile(path))
+    def test_compiled(self):
+        # Setting _pywincffi to None in sys.modules will force
+        # 'import _pywincffi' to fail forcing load() to
+        # compile the module.
+        sys.modules["_pywincffi"] = None
+        loaded = load()
+        self.assertEqual(loaded.mode, "compiled")
 
-    def test_can_import_compiled_module(self):
-        _, path = Distribution.out_of_line()
-        import_module(Distribution.MODULE_NAME, path)
-
-    def test_compiled_module_has_ffi_instance(self):
-        _, path = Distribution.out_of_line()
-        module = import_module(Distribution.MODULE_NAME, path)
-        self.assertTrue(hasattr(module, "ffi"))
-        self.assertEqual(
-            module.ffi.__class__.__name__, "CompiledFFI")
-
-    def test_compiled_module_has_library_instance(self):
-        _, path = Distribution.out_of_line()
-        module = import_module(Distribution.MODULE_NAME, path)
-        self.assertTrue(hasattr(module, "lib"))
-        self.assertEqual(type(module.lib).__name__, "CompiledLib")
-
-    def test_compiled_module_produces_function(self):
-        _, path = Distribution.out_of_line()
-        module = import_module(Distribution.MODULE_NAME, path)
-        func = getattr(module.lib, self.function_name)
-        self.assertEqual(func(1), 2)
-
-
-class TestDistributionLoad(TestDistributionLoadBaseTest):
-    def test_imports_module_cache(self):
-        config.set("pywincffi", "library", "precompiled")
-        module = new_module(Distribution.MODULE_NAME)
-        module.ffi = 3
-        module.lib = 4
-        sys.modules.update({Distribution.MODULE_NAME: module})
-        self.addCleanup(sys.modules.pop, Distribution.MODULE_NAME)
-        self.assertEqual(Distribution.load(), (3, 4))
-        self.assertIs(Distribution._pywincffi, module)
-
-    def test_compiles_module_inline(self):
-        config.set("pywincffi", "library", "inline")
-
-        with patch.object(Distribution, "_pywincffi", None):
-            ffi_, library = Distribution.load()
-
-        self.assertIsInstance(ffi_, FFI)
-        self.assertEqual(library.__class__.__name__, "FFILibrary")
-
-    def test_calls_inline_for_compile_error(self):
-        tempdir = self.tempdir()
-        with open(join(tempdir, "__init__.py"), "w"):
-            pass
-
-        with open(join(tempdir, "_pywincffi.py"), "w") as _pywincffi:
-            _pywincffi.write("raise ImportError('fail')" + os.linesep)
-
-        sys.path.insert(0, tempdir)
-        self.addCleanup(sys.path.remove, tempdir)
-
-        _, lib = Distribution.load()
-        self.assertIsInstance(Distribution._pywincffi, InlineModule)
-        func = getattr(lib, self.function_name)
-        self.assertEqual(func(1), 2)
-
-
-class TestFFIFunction(TestDistributionLoadBaseTest):
-    def test_all_export(self):
-        self.assertIn("ffi", __all__)
-
-    def test_calls_implementation_function(self):
-        with patch.object(Distribution, "out_of_line") as mocked:
-            ffi()
-
-        mocked.assert_called_with(compile_=False)
-
-    def test_return_value(self):
-        with patch.object(Distribution, "out_of_line", return_value=(1, 2)):
-            result = ffi()
-
-        self.assertEqual(result, 1)
-
-
-class TestLoadFunction(TestDistributionLoadBaseTest):
-    def test_all_export(self):
-        self.assertIn("load", __all__)
-
-    def test_calls_implementation_function(self):
-        with patch.object(Distribution, "load") as mocked:
-            load()
-
-        mocked.assert_called_once_with()
-
-    def test_return_value(self):
-        with patch.object(Distribution, "load", return_value=(1, 2)):
-            result = load()
-
-        self.assertEqual(result, (1, 2))

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -117,8 +117,11 @@ class TestRead(TestCase):
         self.assertEqual(_read(*temp_files), expected_output)
 
     def test_raises_resource_not_found_error(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        os.remove(path)
         with self.assertRaises(ResourceNotFoundError):
-            _read("")
+            _read(path)
 
 
 class TestFFI(TestCase):

--- a/tests/test_kernel32/test_io.py
+++ b/tests/test_kernel32/test_io.py
@@ -13,7 +13,7 @@ from pywincffi.kernel32.io import (
 try:
     WindowsError
 except NameError:
-    WindowsError = OSError
+    WindowsError = OSError  # pylint: disable=redefined-builtin
 
 
 class PipeBaseTestCase(TestCase):


### PR DESCRIPTION
The `pywincffi.core.dist` module previously was more complex then necessary.  This PR aims to fix a few problems with the current implementation, see the checklist below for additional details.
- [x] **There are two ways to interact with `_pywincffi`, out of line and inline mode, there should only be one**.  The two have slightly different behaviors and one, inline mode, has some different behaviors compared to the out of line compiled module (which is what will come from PyPi).  By standardizing on one way of building and using the module some tests cases can be removed and the build steps can be simplified too.
  - [x] Remove the test steps which build and run in the two different modes.
- [x] **dist.py should not require work arounds or mocks to compose different behaviors.**.  For example the compile step was tightly integrated instancing the `FFI` instance when it could be a two step process.  This will allow for easier testing and more code reuse.
- [x] **Code, rather than a configuration file, should drive caching**.  Right now you can control if a module is built and cached using a configuration file.  This was done so tests could be always work with the underlying `_pywincffi` without caching.  This however is more complicated and could lead to unexpected behavior in a test if a configuration file is left on disk.  Instead the test framework should drive this and individual test units should override the behavior if necessary.
  - [x] Update core TestCase to reflect this change.
  - [x] Reevaluate test cases that were using mocks with the inline module.
- [x] **Implementation details shouldn't be exposed**.  Most of the non-core code and the main documentation for dist.py does not reference any function except ``pywincffi.core.dist`.  The limit confusion only this method should be treated as 'public'.
