### PR TITLE
Release 0.1.1 Preparation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,11 +49,11 @@ Development
 Python Version Support
 ----------------------
 
-This project supports Python 2.6 and up including
-Python 3.  PRs, patches, tests etc that don't include
-support for both 2.x and 3.x will not be merged.  The
-aim is also the support both major versions of Python within
-the same code base rather than rely on tools such as 2to3.
+This project supports Python 2.6 and up including Python 3.x.  PRs, patches,
+tests etc that don't include support for both 2.x and 3.x will not be
+merged.  The aim is also the support both major versions of Python within
+the same code base rather than rely on tools such as 2to3, six or other
+libraries for the most part.
 
 Documentation
 -------------
@@ -64,9 +64,13 @@ It's generated directly from this library using sphinx::
 
     virtualenv env
     env/bin/activate
-    PYWINCFFI_INSTALL_BUILD=1 pip install -e .
+    pip install -r dev_requirements.txt
+    pip install -e .
     cd docs
     make html
+
+The build process also builds the documentation to ensure there are not
+any obvious problems (including broken links).
 
 Function Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -75,41 +79,82 @@ Windows API Functions are typically documented in the following format:
 
 .. code-block:: python
 
-    def DuplicateHandle(arg1):
+    def DuplicateHandle(arg1, kwarg1=None):
         """
         A brief message about this function.
-
-        :param type arg1:
-            Brief information about this argument
 
         .. seealso::
 
             <url to the MSDN API documentation for this function>
+
+        :param type arg1:
+            Brief information about this argument
+
+        :keyword type kwarg1:
+            Brief information about this keyword include it's default
+            and how it's handled within the function.
+
+        :raises SomeException:
+            Some information on when this exception will be raised
+
+        :rtype: type
+        :return:
+            Information about the data that's returned
         """
 
-It's important to note that the docs also contain a ``seealso`` link which
-points back to the original documentation provided by Microsoft.  The link will
-contain more detailed information about a function's specific behaviors and
-caveats than pywincffi's docs may provide alone.
+It's important to note that the docs contain a ``seealso`` stanza.  This is
+typically used to reference the MSDN documentation but may also be used to
+reference examples, white papers or other reference which may be useful in
+describing the function.
 
 
 Testing
 -------
 
+Nosetests
+~~~~~~~~~
 Tests are located in the ``tests/`` directory.  The tests
 themselves are run using ``nosetests`` either manually or using
 the ``setup.py`` file::
 
     virtualenv env
     env/bin/activate
+    pip install -r dev_requirements.txt
     pip install -e .
-    python setup.py test
+    nosetests tests
 
-Every commit and pull request is also executed on
-`AppVeyor <https://ci.appveyor.com/project/opalmer/pywincffi>`_.  Tests can also
-be executed manually as well::
+Continuous Integration
+~~~~~~~~~~~~~~~~~~~~~~
 
-    nosetests -v --with-coverage
+To consistently ensure the highest quality code, the following services are
+utilized to test or analyze every commit and pull request:
 
-You can also follow `the documentation <https://pywincffi.readthedocs.org/en/latest/dev/vagrant.html>`_
-and use Vagrant to test locally on non-Windows platforms.
+    * `AppVeyor <https://ci.appveyor.com/project/opalmer/pywincffi>`_ - Runs
+      the unittests, builds wheel files, MSIs and other output artifacts
+      which can be published in a release.
+    * `Travis <https://travis-ci.org/opalmer/pywincffi>`_ - Runs the ``pep8``
+      and ``pylint`` command line tools on the code base and tests.  This also
+      builds the docs so documentation problems are easily spotted.
+    * `Codecov <https://codecov.io/github/opalmer/pywincffi>`_ - Analyses and
+      displays code coverage results after tests have run on AppVeyor.  Results
+      are posted back to pull requests.
+    * `ReadTheDocs <https://readthedocs.org/projects/pywincffi/builds/>`_. -
+      The official location where documentation is built and posted.  This is
+      generally for merges into the master branch however.
+
+
+Vagrant
+~~~~~~~
+
+The continuous integration service above negate most of the need to setup
+your local workstation to handle development for pywincffi even if you're not
+running Windows.  In some cases however, such as when working on large
+changes, it can be faster to test locally.
+
+If you're not running Windows or you don't have the tools necessary to
+develop pywincffi on your machine you can use
+`Vagrant <https://www.vagrantup.com/>`_ to build a Windows machine and start
+developing.  There's a more in depth explanation of this process located
+here:
+
+    https://pywincffi.readthedocs.org/en/latest/dev/vagrant.html

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ Python Windows Wrapper Using CFFI
     :target: https://codecov.io/github/opalmer/pywincffi?branch=master
     :alt: code coverage
 
-.. image:: https://readthedocs.org/projects/pywincffi/badge/?version=latest
-    :target: http://pywincffi.readthedocs.org/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/pywincffi/badge/
+    :target: https://pywincffi.readthedocs.org/
     :alt: documentation badge
 
 

--- a/README.rst
+++ b/README.rst
@@ -18,13 +18,29 @@ Python Windows Wrapper Using CFFI
     :alt: documentation badge
 
 
-This library is a wrapper around some Windows functions using Python
-and CFFI.  The repository was originally created to assist the Twisted
-project in moving away from pywin32 so installation does not require a compile
-step.
+``pywincffi`` is a wrapper around some Windows API functions using Python
+and the `cffi <https://cffi.readthedocs.org>`_ library.  This project was
+originally created to assist the Twisted project in moving away from its
+dependency on ``pywin32``.  Contributions to expand on the APIs which pywincffi
+offers are always welcome however.
 
-That said, contributions to this project to expand on the functionality are
-always welcome.
+The core objectives and design principles behind this project are:
+
+    * It should be easier to to use Windows API functions both in terms of
+      implementation and distribution.
+    * Python 2.6, 2.7 and 3.x should be supported from a single code base and
+      not require a consumer of pywincffi to worry about how they use the
+      library.
+    * Type conversion, error checking and other 'C like' code should be the
+      responsibility of the library where possible.
+    * APIs provided by pywincffi should mirror their Windows counterparts as
+      closely as possible so the MSDN documentation can be more easily used as
+      reference.
+    * Documentation and error messages should be descriptive, consistent,
+      complete and accessible.  Examples should be provided for more complex
+      use cases.
+    * For contributors, it should be possible to develop and test regardless
+      of what platform the contributor is coming from.
 
 
 Development

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,10 @@ The core objectives and design principles behind this project are:
 Development
 ===========
 
+This section gives a basic overview of the development process including
+the major goals.  This is not comprehensive but should be a good
+introduction before submitting a pull request.
+
 Python Version Support
 ----------------------
 
@@ -146,10 +150,10 @@ utilized to test or analyze every commit and pull request:
 Vagrant
 ~~~~~~~
 
-The continuous integration service above negate most of the need to setup
-your local workstation to handle development for pywincffi even if you're not
-running Windows.  In some cases however, such as when working on large
-changes, it can be faster to test locally.
+The continuous integration services above negate most of the need to setup
+your local workstation to handle development for pywincffi, even if you're not
+running Windows.  In some cases however it can be faster or easiear to work
+on your local machine.
 
 If you're not running Windows or you don't have the tools necessary to
 develop pywincffi on your machine you can use

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ Versions
 ~~~~~
 
 The first public release of pywincffi.  The
-`GitHub release <https://github.com/opalmer/pywincffi/releases/tag/test2>`_
+`GitHub release <https://github.com/opalmer/pywincffi/releases/tag/0.1.1>`_
 contains the full list of issues, change and pull requests.  This is also
 the first release which should allow Twisted to start moving away from pywin32.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,8 +13,9 @@ Versions
 
 The first public release of pywincffi.  The
 `GitHub release <https://github.com/opalmer/pywincffi/releases/tag/0.1.1>`_
-contains the full list of issues, change and pull requests.  This is also
-the first release which should allow Twisted to start moving away from pywin32.
+contains the full list of issues, changes and pull requests.  The primary
+purpose of this release was to end up with the tools and code necessary to
+begin integrating pywincffi into Twisted.
 
 
 0.1.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,24 @@
+Changelog
+=========
+
+This document contains information on pywincff's release history.  Later
+versions are shown first.
+
+
+Versions
+--------
+
+0.1.1
+~~~~~
+
+The first public release of pywincffi.  The
+`GitHub release <https://github.com/opalmer/pywincffi/releases/tag/test2>`_
+contains the full list of issues, change and pull requests.  This is also
+the first release which should allow Twisted to start moving away from pywin32.
+
+
+0.1.0
+~~~~~
+
+This was an internal test release.  No data was published to PyPi or GitHub.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,18 +29,22 @@ The core objectives and design principles behind this project are:
 
     `PyWinCFFI's README <https://github.com/opalmer/pywincffi/blob/master/README.rst>`_
 
+
 Main Index
 ==========
+
+.. toctree:: changelog.rst
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
 
+
 Python Package
 ==============
 
 .. toctree:: modules/modules.rst
-
+    :maxdepth: 4
 
 Development
 ===========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,16 +1,33 @@
 Welcome to PyWinCFFI's documentation!
 =====================================
 
-This library is a wrapper around some Windows functions using Python
-and CFFI.  The repository was originally created to assist the Twisted
-project in moving away from pywin32 so installation does not require a compile
-step.
+``pywincffi`` is a wrapper around some Windows API functions using Python
+and the `cffi <https://cffi.readthedocs.org>`_ library.  This project was
+originally created to assist the Twisted project in moving away from its
+dependency on ``pywin32``.  Contributions to expand on the APIs which pywincffi
+offers are always welcome however.
 
-For more information, see the sections below for the module index.
+The core objectives and design principles behind this project are:
 
-.. todo::
+    * It should be easier to to use Windows API functions both in terms of
+      implementation and distribution.
+    * Python 2.6, 2.7 and 3.x should be supported from a single code base and
+      not require a consumer of pywincffi to worry about how they use the
+      library.
+    * Type conversion, error checking and other 'C like' code should be the
+      responsibility of the library where possible.
+    * APIs provided by pywincffi should mirror their Windows counterparts as
+      closely as possible so the MSDN documentation can be more easily used as
+      reference.
+    * Documentation and error messages should be descriptive, consistent,
+      complete and accessible.  Examples should be provided for more complex
+      use cases.
+    * For contributors, it should be possible to develop and test regardless
+      of what platform the contributor is coming from.
 
-    Add a few sections to supplement/expand on what's in the README.
+.. seealso::
+
+    `PyWinCFFI's README <https://github.com/opalmer/pywincffi/blob/master/README.rst>`_
 
 Main Index
 ==========

--- a/pywincffi/__init__.py
+++ b/pywincffi/__init__.py
@@ -2,9 +2,8 @@
 PyWinCFFI
 =========
 
-A core Python package that uses :mod:`cffi` to interact
-with Windows APIs.  See :ref:`modindex` for more detailed
-information.
+The root of the pywincffi package.  See the ``README`` and documentation for
+help and examples.
 """
 
 __version__ = (0, 1, 1)

--- a/pywincffi/__init__.py
+++ b/pywincffi/__init__.py
@@ -6,4 +6,5 @@ A core Python package that uses :mod:`cffi` to interact
 with Windows APIs.  See :ref:`modindex` for more detailed
 information.
 """
-__version__ = (0, 1, 0)
+
+__version__ = (0, 1, 1)

--- a/pywincffi/core/__init__.py
+++ b/pywincffi/core/__init__.py
@@ -2,6 +2,7 @@
 Core Sub-Package
 ================
 
-The core package is used internally by pywincffi.  See the documentation
-for each module for more information.
+An internal package used by pywincffi for loading the underlying ``_pywincffi``
+module, handling configuration data, logging and other common tasks.  This
+package also contains the C source and header files.
 """

--- a/pywincffi/dev/__init__.py
+++ b/pywincffi/dev/__init__.py
@@ -3,5 +3,6 @@ Development Sub-Package
 =======================
 
 This package is used for development, testing and release purposes.  It
-does not contain core functionality of pywincffi.
+does not contain core functionality of pywincffi and is unused by
+:mod:`pywincffi.core`, :mod:`pywincffi.kernel32` and other similar modules.
 """

--- a/pywincffi/kernel32/__init__.py
+++ b/pywincffi/kernel32/__init__.py
@@ -2,6 +2,6 @@
 Kernel32 Sub-Package
 ====================
 
-Provides functions, constants and utilities that wrap the Windows
-kernel32 library.
+Provides functions, constants and utilities that wrap functions provided by
+``kernel32.dll``.
 """


### PR DESCRIPTION
Update to version 0.1.1 and prepare for the first release.  0.1.0 was a used as an internal test.

**NOTE** - The link check step for the documentation build will fail on Travis because the release does not exist yet.
