### PR TITLE
Require cffi >= 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except (OSError, IOError, WindowsError) as error:
         raise
 
 requirements = [
-    "cffi>=1.0.0",
+    "cffi>=1.4.1",
     "six"
 ]
 


### PR DESCRIPTION
Previous versions of cffi didn't know about common
types or any of the Windows types when using an out-of-line
module.  Version 1.4.0 if cffi should fix contain a fix however:

  https://bitbucket.org/cffi/cffi/issues/228/bool-type-as-callback-argument-not-working

Rather than requiring 1.4.0+ we're using 1.4.1+ because of another issue:

  https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-4-1
