### PR TITLE
OpenProcess returns an invalid handle

### DIFF
--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -48,11 +48,10 @@ def OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId):
     input_check("dwProcessId", dwProcessId, six.integer_types)
     ffi, library = dist.load()
 
-    handle_id = library.OpenProcess(
+    handle = library.OpenProcess(
         ffi.cast("DWORD", dwDesiredAccess),
         ffi.cast("BOOL", bInheritHandle),
         ffi.cast("DWORD", dwProcessId)
     )
     error_check("OpenProcess")
-
-    return ffi.new_handle(handle_id)
+    return handle

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -3,6 +3,7 @@ import os
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError
+from pywincffi.kernel32.io import CloseHandle
 from pywincffi.kernel32.process import OpenProcess
 
 
@@ -29,3 +30,11 @@ class TestOpenProcess(TestCase):
             OpenProcess(0, False, os.getpid())
 
         self.assertEqual(error.exception.code, 5)
+
+    def test_handle_is_valid(self):
+        ffi, library = dist.load()
+        handle = OpenProcess(
+            library.PROCESS_QUERY_INFORMATION, False, os.getpid())
+
+        # If the handle were invalid, this would fail.
+        CloseHandle(handle)

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -16,7 +16,7 @@ class TestOpenProcess(TestCase):
 
         handle = OpenProcess(
             # pylint: disable=no-member
-            library.PROCESS_QUERY_LIMITED_INFORMATION,
+            library.PROCESS_QUERY_INFORMATION,
             False,
             os.getpid()
         )

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -15,7 +15,6 @@ class TestOpenProcess(TestCase):
         ffi, library = dist.load()
 
         handle = OpenProcess(
-            # pylint: disable=no-member
             library.PROCESS_QUERY_INFORMATION,
             False,
             os.getpid()
@@ -33,7 +32,7 @@ class TestOpenProcess(TestCase):
         self.assertEqual(error.exception.code, 5)
 
     def test_handle_is_valid(self):
-        ffi, library = dist.load()
+        _, library = dist.load()
         handle = OpenProcess(
             library.PROCESS_QUERY_INFORMATION, False, os.getpid())
 

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -24,6 +24,7 @@ class TestOpenProcess(TestCase):
         typeof = ffi.typeof(handle)
         self.assertEqual(typeof.kind, "pointer")
         self.assertEqual(typeof.cname, "void *")
+        CloseHandle(handle)
 
     def test_access_denied_for_null_desired_access(self):
         with self.assertRaises(WindowsAPIError) as error:


### PR DESCRIPTION
The `pywincffi.kernel32.process.OpenProcess` was returning an invalid handle that could not be used by other functions.  This was discovered while working on the check_pid_exists branch.

This fixes issues encountered when working on #48 and #49.
