### PR TITLE
Implement GetProcessId() and GetCurrentProcess()

### DIFF
--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -11,6 +11,7 @@ VOID SetLastError(DWORD);
 // Processes
 HANDLE OpenProcess(DWORD, BOOL, DWORD);
 HANDLE GetCurrentProcess();
+DWORD GetProcessId(HANDLE);
 
 // Pipes
 BOOL CreatePipe(PHANDLE, PHANDLE, LPSECURITY_ATTRIBUTES, DWORD);

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -10,6 +10,7 @@ VOID SetLastError(DWORD);
 
 // Processes
 HANDLE OpenProcess(DWORD, BOOL, DWORD);
+HANDLE GetCurrentProcess();
 
 // Pipes
 BOOL CreatePipe(PHANDLE, PHANDLE, LPSECURITY_ATTRIBUTES, DWORD);

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -18,7 +18,7 @@ documentation for the constant names and their purpose:
 import six
 
 from pywincffi.core import dist
-from pywincffi.core.checks import input_check, error_check
+from pywincffi.core.checks import Enums, input_check, error_check
 
 
 def OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId):
@@ -76,3 +76,25 @@ def GetCurrentProcess():
     """
     _, library = dist.load()
     return library.GetCurrentProcess()
+
+
+def GetProcessId(Process):
+    """
+    Returns the pid of the process handle provided in ``Process``.
+
+    .. seealso::
+
+        https://msdn.microsoft.com/en-us/library/ms683215
+
+    :param handle Process:
+        The handle of the process to re
+
+    :return:
+        Returns an integer which represents the pid of the given
+        process handle.
+    """
+    input_check("Process", Process, Enums.HANDLE)
+    _, library = dist.load()
+    pid = library.GetProcessId(Process)
+    error_check("GetProcessId")
+    return pid

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -77,7 +77,7 @@ def GetCurrentProcess():
     return library.GetCurrentProcess()
 
 
-def GetProcessId(Process):
+def GetProcessId(Process):  # pylint: disable=invalid-name
     """
     Returns the pid of the process handle provided in ``Process``.
 

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -56,3 +56,23 @@ def OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId):
     error_check("OpenProcess")
 
     return ffi.new_handle(handle_id)
+
+
+def GetCurrentProcess():
+    """
+    Returns a handle to the current thread.
+
+    .. seealso::
+
+        https://msdn.microsoft.com/en-us/library/ms683179
+
+    .. note::
+
+        Calling :func:`pywincffi.kernel32.io.CloseHandle` on the handle
+        produced by this function will produce an exception.
+
+    :returns:
+        The handle to the current process.
+    """
+    _, library = dist.load()
+    return library.GetCurrentProcess()

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -3,7 +3,7 @@ import os
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError
-from pywincffi.kernel32.process import OpenProcess
+from pywincffi.kernel32.process import OpenProcess, GetCurrentProcess
 
 
 class TestOpenProcess(TestCase):
@@ -29,3 +29,23 @@ class TestOpenProcess(TestCase):
             OpenProcess(0, False, os.getpid())
 
         self.assertEqual(error.exception.code, 5)
+
+
+class TestGetCurrentProcess(TestCase):
+    """
+    Tests for :func:`pywincffi.kernel32.GetCurrentProcess`
+    """
+    def test_returns_handle(self):
+        ffi, library = dist.load()
+        handle = GetCurrentProcess()
+        typeof = ffi.typeof(handle)
+        self.assertEqual(typeof.kind, "pointer")
+        self.assertEqual(typeof.cname, "void *")
+
+    def test_returns_same_handle(self):
+        # GetCurrentProcess is somewhat special in that it will
+        # always return a handle to the same object.  However, __eq__ is not
+        # opaque so the string representation of the two handles
+        # should always match since it contains the address of the object
+        # in memory.
+        self.assertEqual(repr(GetCurrentProcess()), repr(GetCurrentProcess()))

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -8,7 +8,7 @@ from pywincffi.kernel32.process import OpenProcess, GetCurrentProcess
 
 class TestOpenProcess(TestCase):
     """
-    Tests for :func:`pywincffi.kernel32.OpenProcess`
+    Tests for :func:`pywincffi.kernel32.process.OpenProcess`
     """
     def test_returns_handle(self):
         ffi, library = dist.load()
@@ -33,7 +33,7 @@ class TestOpenProcess(TestCase):
 
 class TestGetCurrentProcess(TestCase):
     """
-    Tests for :func:`pywincffi.kernel32.GetCurrentProcess`
+    Tests for :func:`pywincffi.kernel32.process.GetCurrentProcess`
     """
     def test_returns_handle(self):
         ffi, library = dist.load()

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -32,6 +32,18 @@ class TestOpenProcess(TestCase):
 
         self.assertEqual(error.exception.code, 5)
 
+    def test_get_process_id_current_process(self):
+        # We should be able to access the pid of the process
+        # we created a handle to.
+        ffi, library = dist.load()
+
+        handle = OpenProcess(
+            library.PROCESS_QUERY_INFORMATION,
+            False,
+            os.getpid()
+        )
+        self.assertEqual(GetProcessId(handle), os.getpid())
+
 
 class TestGetCurrentProcess(TestCase):
     """

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -3,7 +3,8 @@ import os
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError
-from pywincffi.kernel32.process import OpenProcess, GetCurrentProcess
+from pywincffi.kernel32.process import (
+    OpenProcess, GetCurrentProcess, GetProcessId)
 
 
 class TestOpenProcess(TestCase):
@@ -49,3 +50,7 @@ class TestGetCurrentProcess(TestCase):
         # should always match since it contains the address of the object
         # in memory.
         self.assertEqual(repr(GetCurrentProcess()), repr(GetCurrentProcess()))
+
+    def test_handle_is_current_process(self):
+        handle = GetCurrentProcess()
+        self.assertEqual(GetProcessId(handle), os.getpid())

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -37,7 +37,7 @@ class TestOpenProcess(TestCase):
     def test_get_process_id_current_process(self):
         # We should be able to access the pid of the process
         # we created a handle to.
-        ffi, library = dist.load()
+        _, library = dist.load()
 
         handle = OpenProcess(
             library.PROCESS_QUERY_INFORMATION,
@@ -53,7 +53,7 @@ class TestGetCurrentProcess(TestCase):
     Tests for :func:`pywincffi.kernel32.process.GetCurrentProcess`
     """
     def test_returns_handle(self):
-        ffi, library = dist.load()
+        ffi, _ = dist.load()
         handle = GetCurrentProcess()
         typeof = ffi.typeof(handle)
         self.assertEqual(typeof.kind, "pointer")


### PR DESCRIPTION
Adding these functions because they're useful inside of other Windows API calls as well as in testing.  This will likely end up being used in #48.
