### PR TITLE
Create pywincffi.kernel32.handle module

### DIFF
--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -5,7 +5,6 @@
 //
 
 // Custom functions
-HANDLE handle_from_fd(int);
 VOID SetLastError(DWORD);
 
 // Processes
@@ -22,6 +21,7 @@ BOOL SetNamedPipeHandleState(HANDLE, LPDWORD, LPDWORD, LPDWORD);
 BOOL WriteFile(HANDLE, LPCVOID, DWORD, LPDWORD, LPOVERLAPPED);
 BOOL ReadFile(HANDLE, LPVOID, DWORD, LPDWORD, LPOVERLAPPED);
 
-// Misc IO
+// Handles
+HANDLE handle_from_fd(int);
 BOOL CloseHandle(HANDLE);
 HANDLE GetStdHandle(DWORD);

--- a/pywincffi/dev/release.py
+++ b/pywincffi/dev/release.py
@@ -263,7 +263,7 @@ class GitHubAPI(object):  # pylint: disable=too-many-instance-attributes
 
             if "refactor" in labels:
                 issue_type = "refactor"
-                
+
             elif "bug" in labels:
                 issue_type = "bugs"
 

--- a/pywincffi/dev/release.py
+++ b/pywincffi/dev/release.py
@@ -261,7 +261,10 @@ class GitHubAPI(object):  # pylint: disable=too-many-instance-attributes
                 logger.warning(
                     "Issue %s is still a work in progress", issue.number)
 
-            if "bug" in labels:
+            if "refactor" in labels:
+                issue_type = "refactor"
+                
+            elif "bug" in labels:
                 issue_type = "bugs"
 
             elif "enhancement" in labels:

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -1,0 +1,8 @@
+"""
+Handles
+-------
+
+A module containing general functions for working with handle
+objects.
+"""
+

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -14,6 +14,29 @@ from pywincffi.exceptions import WindowsAPIError
 INVALID_HANDLE_VALUE = -1
 
 
+def handle_from_file(python_file):
+    """
+    Given a standard Python file object produce a Windows
+    handle object that be be used in Windows function calls.
+
+    :param file python_file:
+        The Python file object to convert to a Windows handle.
+
+    :return:
+        Returns a Windows handle object which is pointing at
+        the provided ``python_file`` object.
+    """
+    _, library = dist.load()
+    input_check("python_file", python_file, Enums.PYFILE)
+
+    # WARNING:
+    #   Be aware that passing in an invalid file descriptor
+    #   number can crash Python.  The input_check function
+    #   above should handle this for us by checking to
+    #   ensure the file descriptor is valid first.
+    return library.handle_from_fd(python_file.fileno())
+
+
 def GetStdHandle(nStdHandle):
     """
     Retrieves a handle to the specified standard

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -7,7 +7,7 @@ objects.
 """
 
 from pywincffi.core import dist
-from pywincffi.core.checks import input_check
+from pywincffi.core.checks import Enums, input_check, error_check
 from pywincffi.exceptions import WindowsAPIError
 
 
@@ -44,3 +44,21 @@ def GetStdHandle(nStdHandle):
             "not %s" % INVALID_HANDLE_VALUE)
 
     return handle
+
+
+def CloseHandle(hObject):
+    """
+    Closes an open object handle.
+
+    .. seealso::
+
+        https://msdn.microsoft.com/en-us/library/ms724211
+
+    :param handle hObject:
+        The handle object to close.
+    """
+    input_check("hObject", hObject, Enums.HANDLE)
+    _, library = dist.load()
+
+    code = library.CloseHandle(hObject)
+    error_check("CloseHandle", code=code, expected=Enums.NON_ZERO)

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -6,3 +6,5 @@ A module containing general functions for working with handle
 objects.
 """
 
+INVALID_HANDLE_VALUE = -1
+

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -6,5 +6,41 @@ A module containing general functions for working with handle
 objects.
 """
 
+from pywincffi.core import dist
+from pywincffi.core.checks import input_check
+from pywincffi.exceptions import WindowsAPIError
+
+
 INVALID_HANDLE_VALUE = -1
 
+
+def GetStdHandle(nStdHandle):
+    """
+    Retrieves a handle to the specified standard
+    device (standard input, standard output, or standard error).
+
+    .. seealso::
+
+        https://msdn.microsoft.com/en-us/library/ms683231
+
+    :param int nStdHandle:
+        The standard device to retrieve
+
+    :rtype: handle
+    :return:
+        Returns a handle to the standard device retrieved.
+    """
+    _, library = dist.load()
+    input_check("nStdHandle", nStdHandle,
+                allowed_values=(library.STD_INPUT_HANDLE,
+                                library.STD_OUTPUT_HANDLE,
+                                library.STD_ERROR_HANDLE))
+
+    handle = library.GetStdHandle(nStdHandle)
+
+    if handle == INVALID_HANDLE_VALUE:  # pragma: no cover
+        raise WindowsAPIError(
+            "GetStdHandle", "Invalid Handle", INVALID_HANDLE_VALUE,
+            "not %s" % INVALID_HANDLE_VALUE)
+
+    return handle

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -11,8 +11,6 @@ from six import integer_types
 
 from pywincffi.core import dist
 from pywincffi.core.checks import Enums, input_check, error_check, NoneType
-from pywincffi.exceptions import WindowsAPIError
-from pywincffi.kernel32.handle import INVALID_HANDLE_VALUE
 
 PeekNamedPipeResult = namedtuple(
     "PeekNamedPipeResult",
@@ -314,21 +312,4 @@ def ReadFile(hFile, nNumberOfBytesToRead, lpOverlapped=None):
     error_check("ReadFile", code=code, expected=Enums.NON_ZERO)
     return ffi.string(lpBuffer)
 
-
-def CloseHandle(hObject):
-    """
-    Closes an open object handle.
-
-    .. seealso::
-
-        https://msdn.microsoft.com/en-us/library/ms724211
-
-    :param handle hObject:
-        The handle object to close.
-    """
-    input_check("hObject", hObject, Enums.HANDLE)
-    _, library = dist.load()
-
-    code = library.CloseHandle(hObject)
-    error_check("CloseHandle", code=code, expected=Enums.NON_ZERO)
 

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -19,29 +19,6 @@ PeekNamedPipeResult = namedtuple(
 )
 
 
-def handle_from_file(python_file):
-    """
-    Given a standard Python file object produce a Windows
-    handle object that be be used in Windows function calls.
-
-    :param file python_file:
-        The Python file object to convert to a Windows handle.
-
-    :return:
-        Returns a Windows handle object which is pointing at
-        the provided ``python_file`` object.
-    """
-    _, library = dist.load()
-    input_check("python_file", python_file, Enums.PYFILE)
-
-    # WARNING:
-    #   Be aware that passing in an invalid file descriptor
-    #   number can crash Python.  The input_check function
-    #   above should handle this for us by checking to
-    #   ensure the file descriptor is valid first.
-    return library.handle_from_fd(python_file.fileno())
-
-
 def CreatePipe(nSize=0, lpPipeAttributes=None):
     """
     Creates an anonymous pipe and returns the read and write handles.

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -332,34 +332,3 @@ def CloseHandle(hObject):
     code = library.CloseHandle(hObject)
     error_check("CloseHandle", code=code, expected=Enums.NON_ZERO)
 
-
-def GetStdHandle(nStdHandle):
-    """
-    Retrieves a handle to the specified standard
-    device (standard input, standard output, or standard error).
-
-    .. seealso::
-
-        https://msdn.microsoft.com/en-us/library/ms683231
-
-    :param int nStdHandle:
-        The standard device to retrieve
-
-    :rtype: handle
-    :return:
-        Returns a handle to the standard device retrieved.
-    """
-    _, library = dist.load()
-    input_check("nStdHandle", nStdHandle,
-                allowed_values=(library.STD_INPUT_HANDLE,
-                                library.STD_OUTPUT_HANDLE,
-                                library.STD_ERROR_HANDLE))
-
-    handle = library.GetStdHandle(nStdHandle)
-
-    if handle == INVALID_HANDLE_VALUE:  # pragma: no cover
-        raise WindowsAPIError(
-            "GetStdHandle", "Invalid Handle", INVALID_HANDLE_VALUE,
-            "not %s" % INVALID_HANDLE_VALUE)
-
-    return handle

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -12,14 +12,13 @@ from six import integer_types
 from pywincffi.core import dist
 from pywincffi.core.checks import Enums, input_check, error_check, NoneType
 from pywincffi.exceptions import WindowsAPIError
+from pywincffi.kernel32.handle import INVALID_HANDLE_VALUE
 
 PeekNamedPipeResult = namedtuple(
     "PeekNamedPipeResult",
     ("lpBuffer", "lpBytesRead", "lpTotalBytesAvail",
      "lpBytesLeftThisMessage")
 )
-
-INVALID_HANDLE_VALUE = -1
 
 
 def handle_from_file(python_file):

--- a/pywincffi/kernel32/io.py
+++ b/pywincffi/kernel32/io.py
@@ -288,5 +288,3 @@ def ReadFile(hFile, nNumberOfBytesToRead, lpOverlapped=None):
     )
     error_check("ReadFile", code=code, expected=Enums.NON_ZERO)
     return ffi.string(lpBuffer)
-
-

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -67,7 +67,7 @@ def GetCurrentProcess():
 
     .. note::
 
-        Calling :func:`pywincffi.kernel32.io.CloseHandle` on the handle
+        Calling :func:`pywincffi.kernel32.handle.CloseHandle` on the handle
         produced by this function will produce an exception.
 
     :returns:

--- a/tests/test_kernel32/test_handle.py
+++ b/tests/test_kernel32/test_handle.py
@@ -8,6 +8,11 @@ from pywincffi.exceptions import InputError
 from pywincffi.kernel32.handle import (
     GetStdHandle, CloseHandle, handle_from_file)
 
+try:
+    WindowsError
+except NameError:  # pragma: no cover
+    WindowsError = OSError
+
 
 class TestGetStdHandle(TestCase):
     def test_stdin_handle(self):

--- a/tests/test_kernel32/test_handle.py
+++ b/tests/test_kernel32/test_handle.py
@@ -1,6 +1,12 @@
+import os
+import tempfile
+from errno import EBADF
+
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
-from pywincffi.kernel32.handle import GetStdHandle
+from pywincffi.exceptions import InputError
+from pywincffi.kernel32.handle import (
+    GetStdHandle, CloseHandle, handle_from_file)
 
 
 class TestGetStdHandle(TestCase):
@@ -24,3 +30,38 @@ class TestGetStdHandle(TestCase):
             GetStdHandle(library.STD_ERROR_HANDLE),
             library.GetStdHandle(library.STD_ERROR_HANDLE)
         )
+
+
+class TestGetHandleFromFile(TestCase):
+    def test_fails_if_not_a_file(self):
+        with self.assertRaises(InputError):
+            handle_from_file(0)
+
+    def test_fails_if_file_is_not_open(self):
+        fd, _ = tempfile.mkstemp()
+        test_file = os.fdopen(fd, "r")
+        test_file.close()
+
+        with self.assertRaises(InputError):
+            handle_from_file(test_file)
+
+    def test_opens_correct_file_handle(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+
+        test_file = open(path, "w")
+        handle = handle_from_file(test_file)
+
+        CloseHandle(handle)
+
+        # If CloseHandle() was passed the same handle
+        # that test_file is trying to write to the file
+        # and/or flushing it should fail.
+        try:
+            test_file.write("foo")
+            test_file.flush()
+        except (OSError, IOError, WindowsError) as error:
+            # EBADF == Bad file descriptor (because CloseHandle closed it)
+            self.assertEqual(error.errno, EBADF)
+        else:
+            self.fail("Expected os.close(%r) to fail" % fd)

--- a/tests/test_kernel32/test_handle.py
+++ b/tests/test_kernel32/test_handle.py
@@ -1,0 +1,26 @@
+from pywincffi.core import dist
+from pywincffi.dev.testutil import TestCase
+from pywincffi.kernel32.handle import GetStdHandle
+
+
+class TestGetStdHandle(TestCase):
+    def test_stdin_handle(self):
+        _, library = dist.load()
+        self.assertEqual(
+            GetStdHandle(library.STD_INPUT_HANDLE),
+            library.GetStdHandle(library.STD_INPUT_HANDLE)
+        )
+
+    def test_stdout_handle(self):
+        _, library = dist.load()
+        self.assertEqual(
+            GetStdHandle(library.STD_OUTPUT_HANDLE),
+            library.GetStdHandle(library.STD_OUTPUT_HANDLE)
+        )
+
+    def test_stderr_handle(self):
+        _, library = dist.load()
+        self.assertEqual(
+            GetStdHandle(library.STD_ERROR_HANDLE),
+            library.GetStdHandle(library.STD_ERROR_HANDLE)
+        )

--- a/tests/test_kernel32/test_io.py
+++ b/tests/test_kernel32/test_io.py
@@ -146,27 +146,6 @@ class TestPeekNamedPipe(PipeBaseTestCase):
             result.lpTotalBytesAvail, bytes_written - (read_bytes * 2))
 
 
-class TestGetStdHandle(TestCase):
-    def test_stdin_handle(self):
-        _, library = dist.load()
-        self.assertEqual(
-            GetStdHandle(library.STD_INPUT_HANDLE),
-            library.GetStdHandle(library.STD_INPUT_HANDLE)
-        )
-
-    def test_stdout_handle(self):
-        _, library = dist.load()
-        self.assertEqual(
-            GetStdHandle(library.STD_OUTPUT_HANDLE),
-            library.GetStdHandle(library.STD_OUTPUT_HANDLE)
-        )
-
-    def test_stderr_handle(self):
-        _, library = dist.load()
-        self.assertEqual(
-            GetStdHandle(library.STD_ERROR_HANDLE),
-            library.GetStdHandle(library.STD_ERROR_HANDLE)
-        )
 
 
 class TestGetHandleFromFile(TestCase):

--- a/tests/test_kernel32/test_io.py
+++ b/tests/test_kernel32/test_io.py
@@ -2,11 +2,11 @@ import os
 import tempfile
 from errno import EBADF
 
-from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError, InputError
+from pywincffi.kernel32.handle import CloseHandle
 from pywincffi.kernel32.io import (
-    CreatePipe, CloseHandle, WriteFile, ReadFile, GetStdHandle,
+    CreatePipe, WriteFile, ReadFile,
     PeekNamedPipe, PeekNamedPipeResult, handle_from_file)
 
 # For pylint on non-windows platforms
@@ -144,8 +144,6 @@ class TestPeekNamedPipe(PipeBaseTestCase):
         result = PeekNamedPipe(reader, 0)
         self.assertEqual(
             result.lpTotalBytesAvail, bytes_written - (read_bytes * 2))
-
-
 
 
 class TestGetHandleFromFile(TestCase):

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -5,7 +5,7 @@ import sys
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError
-from pywincffi.kernel32.io import CloseHandle
+from pywincffi.kernel32.handle import CloseHandle
 from pywincffi.kernel32.process import (
     OpenProcess, GetCurrentProcess, GetProcessId)
 


### PR DESCRIPTION
There are a few functions which are meant to more generally handle Windows handle objects rather than being specific to processes, files, etc.  This PR moves those functions into a new `pywincffi.kernel32.handle` module.
