### PR TITLE
Cleanup tests for dist.py, ensure dist.py accepts non-default inputs

### DIFF
--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -8,6 +8,8 @@ This module is used by the unittests.
 import os
 import subprocess
 import sys
+from random import choice
+from string import ascii_lowercase, ascii_uppercase
 
 from cffi import FFI, CDefError
 
@@ -91,10 +93,35 @@ class TestCase(_TestCase):
         self.addCleanup(self._terminate_process, process)
         return process
 
-    def clear_list(self, list_):
+    def clear_object(self, thing):
         """
-        Clear a Python list of entries in place.  This function exists
-        for compatibility across Python versions.
+        Attempts to clear all data out of ``thing``.  This will fail the test
+        if we can't handle the type of object provided.
         """
-        assert isinstance(list_, list)
-        del list_[:]
+        try:
+            thing.clear()
+        except AttributeError:
+            if isinstance(thing, list):  # Older version of Python.
+                del thing[:]
+            else:
+                self.fail("Don't know how to clear %s" % type(thing))
+
+    def random_string(self, length):
+        """
+        Returns a random string as long as ``length``.  The first character
+        will always be a letter.  All other characters will be A-F,
+        A-F or 0-9.
+        """
+        if length < 1:
+            self.fail("Length must be at least 1.")
+
+        # First character should always be a letter so the string
+        # can be used in object names.
+        output = choice(ascii_lowercase)
+        length -= 1
+
+        while length:
+            length -= 1
+            output += choice(ascii_lowercase + ascii_uppercase + "0123456789")
+
+        return output

--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -99,7 +99,7 @@ class TestCase(_TestCase):
         will always be a letter.  All other characters will be A-F,
         A-F or 0-9.
         """
-        if length < 1:
+        if length < 1:  # pragma: no cover
             self.fail("Length must be at least 1.")
 
         # First character should always be a letter so the string

--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -93,19 +93,6 @@ class TestCase(_TestCase):
         self.addCleanup(self._terminate_process, process)
         return process
 
-    def clear_object(self, thing):
-        """
-        Attempts to clear all data out of ``thing``.  This will fail the test
-        if we can't handle the type of object provided.
-        """
-        try:
-            thing.clear()
-        except AttributeError:
-            if isinstance(thing, list):  # Older version of Python.
-                del thing[:]
-            else:
-                self.fail("Don't know how to clear %s" % type(thing))
-
     def random_string(self, length):
         """
         Returns a random string as long as ``length``.  The first character

--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -90,3 +90,11 @@ class TestCase(_TestCase):
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.addCleanup(self._terminate_process, process)
         return process
+
+    def clear_list(self, list_):
+        """
+        Clear a Python list of entries in place.  This function exists
+        for compatibility across Python versions.
+        """
+        assert isinstance(list_, list)
+        del list_[:]

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import binascii
 import os
 import shutil
 import sys
@@ -35,19 +34,8 @@ class TestModule(TestCase):
     """
     Tests for :class:`pywincffi.core.dist.Module`
     """
-    def setUp(self):
-        super(TestModule, self).setUp()
-        Module.cache = None
-
-    def tearDown(self):
-        super(TestModule, self).tearDown()
-        Module.cache = None
-        sys.modules.pop("_pywincffi", None)
-
-    def test_cache_default(self):
-        self.assertIsNone(Module.cache)
-
     def test_double_cache_produces_warning(self):
+        self.addCleanup(setattr, Module, "cache", None)
         Module.cache = ""
 
         with warnings.catch_warnings(record=True) as caught:
@@ -76,8 +64,7 @@ class TestImportPath(TestCase):
     """Tests for :func:`pywincffi.core.dist._import_path`"""
     def setUp(self):
         super(TestImportPath, self).setUp()
-        self.module_name = \
-            "m" + binascii.b2a_hex(os.urandom(6)).decode("utf-8")
+        self.module_name = self.random_string(16)
         self.header = "int add(int, int);"
         self.source = "int add(int a, int b) {return a + b;}"
 
@@ -216,9 +203,8 @@ class TestLoad(TestCase):
     """Tests for :func:`pywincffi.core.dist.load`"""
     def setUp(self):
         super(TestLoad, self).setUp()
-        if Module.cache is not None:
-            self.addCleanup(setattr, Module, "cache", Module.cache)
-            Module.cache = None
+        self.addCleanup(setattr, Module, "cache", None)
+        Module.cache = None
 
         if MODULE_NAME in sys.modules:
             self.addCleanup(

--- a/tests/test_core/test_dist.py
+++ b/tests/test_core/test_dist.py
@@ -126,90 +126,104 @@ class TestRead(TestCase):
 
 class TestFFI(TestCase):
     """Tests for :func:`pywincffi.core.dist._ffi`"""
-    def test_sets_unicode(self):
-        with patch.object(FFI, "set_unicode") as mocked_set_unicode:
-            _ffi()
+    def setUp(self):
+        self.module_name = self.random_string(16)
+        self.addCleanup(sys.modules.pop, self.module_name, None)
 
-        mocked_set_unicode.assert_called_once_with(True)
+    def test_calls_set_unicode(self):
+        # Certain types require set_unicode to be called so
+        # this test will fail if ffi.set_unicode(True) is never
+        # called in our core library.
+        fd, header_path = tempfile.mkstemp(suffix=".h")
+        with os.fdopen(fd, "w") as file_:
+            file_.write("BOOL Foobar(LPTSTR);")
 
-    def test_set_source(self):
+        _ffi(module_name=self.module_name, sources=[], headers=[header_path])
+
+    def test_default_source_files(self):
         with patch.object(FFI, "set_source") as mocked_set_source:
-            _ffi()
+            _ffi(module_name=self.module_name)
 
         mocked_set_source.assert_called_once_with(
-            MODULE_NAME, _read(*SOURCE_FILES))
+            self.module_name, _read(*SOURCE_FILES))
 
-    def test_cdef(self):
+    def test_default_cdefs(self):
         with patch.object(FFI, "cdef") as mocked_cdef:
-            _ffi()
+            _ffi(module_name=self.module_name)
 
         mocked_cdef.assert_called_with(_read(*HEADER_FILES))
+
+    def test_alternate_source_files(self):
+        _, path = tempfile.mkstemp(suffix=".h")
+
+        with patch.object(FFI, "set_source") as mocked_set_source:
+            _ffi(module_name=self.module_name, sources=[path])
+
+        mocked_set_source.assert_called_once_with(
+            self.module_name, _read(*[path]))
 
 
 class TestCompile(TestCase):
     """Tests for :func:`pywincffi.core.dist._compile`"""
     def setUp(self):
         super(TestCompile, self).setUp()
-        self.header_files = HEADER_FILES[:]
-        self.source_files = SOURCE_FILES[:]
-
-    def tearDown(self):
-        super(TestCompile, self).tearDown()
-        HEADER_FILES[:] = self.header_files
-        SOURCE_FILES[:] = self.source_files
-        Module.cache = None
-        sys.modules.pop("_pywincffi", None)
+        self.module_name = self.random_string(16)
+        self.addCleanup(sys.modules.pop, self.module_name, None)
+        self.addCleanup(setattr, Module, "cache", None)
 
     def test_compile(self):
         # Create fake header
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        HEADER_FILES[:] = [path]
-
-        with os.fdopen(fd, "w") as header:
-            header.write("int add(int, int);")
+        fd, header = tempfile.mkstemp(suffix=".h")
+        self.addCleanup(os.remove, header)
+        with os.fdopen(fd, "w") as file_:
+            file_.write("int add(int, int);")
 
         # Create fake source
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        SOURCE_FILES[:] = [path]
-        with os.fdopen(fd, "w") as source:
-            source.write("int add(int a, int b) {return a + b;}")
+        fd, source = tempfile.mkstemp(suffix=".c")
+        self.addCleanup(os.remove, source)
+        with os.fdopen(fd, "w") as file_:
+            file_.write(
+                "int add(int a, int b) {return a + b;}")
 
-        ffi = _ffi()
-        module = _compile(ffi)
+        ffi = _ffi(
+            module_name=self.module_name, sources=[source], headers=[header])
+        module = _compile(ffi, module_name=self.module_name)
         self.assertEqual(module.lib.add(1, 2), 3)
 
     def test_compile_uses_provided_tempdir(self):
         # Create fake header
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        HEADER_FILES[:] = [path]
-
-        with os.fdopen(fd, "w") as header:
-            header.write("int add(int, int);")
+        fd, header = tempfile.mkstemp(suffix=".h")
+        self.addCleanup(os.remove, header)
+        with os.fdopen(fd, "w") as file_:
+            file_.write("int add(int, int);")
 
         # Create fake source
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        SOURCE_FILES[:] = [path]
-        with os.fdopen(fd, "w") as source:
-            source.write("int add(int a, int b) {return a + b;}")
+        fd, source = tempfile.mkstemp(suffix=".c")
+        self.addCleanup(os.remove, source)
+        with os.fdopen(fd, "w") as file_:
+            file_.write("int add(int a, int b) {return a + b;}")
 
         tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
 
-        ffi = _ffi()
-        module = _compile(ffi, tmpdir=tmpdir)
+        ffi = _ffi(
+            module_name=self.module_name, sources=[source], headers=[header])
+        module = _compile(ffi, tmpdir=tmpdir, module_name=self.module_name)
         self.assertEqual(dirname(module.__file__), tmpdir)
 
 
 class TestLoad(TestCase):
     """Tests for :func:`pywincffi.core.dist.load`"""
-    def tearDown(self):
-        super(TestLoad, self).tearDown()
-        Module.cache = None
-        sys.modules.pop("_pywincffi", None)
+    def setUp(self):
+        super(TestLoad, self).setUp()
+        if Module.cache is not None:
+            self.addCleanup(setattr, Module, "cache", Module.cache)
+            Module.cache = None
+
+        if MODULE_NAME in sys.modules:
+            self.addCleanup(
+                sys.modules.__setitem__, MODULE_NAME, sys.modules[MODULE_NAME])
+            sys.modules.pop(MODULE_NAME)
 
     def test_cache(self):
         cached = object()
@@ -218,7 +232,7 @@ class TestLoad(TestCase):
 
     def test_prebuilt(self):
         fake_module = Mock(ffi=1, lib=2)
-        sys.modules["_pywincffi"] = fake_module
+        sys.modules[MODULE_NAME] = fake_module
         loaded = load()
         self.assertEqual(loaded.mode, "prebuilt")
 
@@ -226,6 +240,6 @@ class TestLoad(TestCase):
         # Setting _pywincffi to None in sys.modules will force
         # 'import _pywincffi' to fail forcing load() to
         # compile the module.
-        sys.modules["_pywincffi"] = None
+        sys.modules[MODULE_NAME] = None
         loaded = load()
         self.assertEqual(loaded.mode, "compiled")

--- a/tests/test_dev/test_release.py
+++ b/tests/test_dev/test_release.py
@@ -412,11 +412,15 @@ class TestGitHubAPIIssues(GitHubAPICaseWithIssues):
 
     def issue_type(self):
         api = self.api(issues=[
-            FakeIssue(labels=["enhancement"]), FakeIssue(labels=["bug"])
+            FakeIssue(labels=["enhancement"]), FakeIssue(labels=["bug"]),
+            FakeIssue(labels=["refactor"])
         ])
 
         for issue in api.issues():
-            if "bug" in issue.labels:
+            if "refactor" in issue.labels:
+                expected_issue_type = "refactor"
+
+            elif "bug" in issue.labels:
                 expected_issue_type = "bugs"
 
             elif "enhancement" in issue.labels:


### PR DESCRIPTION
This PR fixes a couple of problems:
- Before this change, adding any unicode types to one of the headers would cause test_calls_set_unicode() to fail.
- The tests modified sys.modules and other global states which could introduce bugs in the future.
- It was not possible to force dist.py to use a custom module name or sources.
