### PR TITLE
Create pywincffi.util Module

### DIFF
--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -12,14 +12,15 @@ from random import choice
 from string import ascii_lowercase, ascii_uppercase
 
 from cffi import FFI, CDefError
+from six import PY2, PY3
 
 try:
     # The setup.py file installs unittest2 for Python 2
     # which backports newer test framework features.
-    from unittest2 import TestCase as _TestCase
+    from unittest2 import TestCase as _TestCase, skipUnless
 except ImportError:  # pragma: no cover
     # pylint: disable=wrong-import-order
-    from unittest import TestCase as _TestCase
+    from unittest import TestCase as _TestCase, skipUnless
 
 from pywincffi.core.config import config
 from pywincffi.core.logger import get_logger
@@ -36,6 +37,10 @@ except NameError:  # pragma: no cover
 # so we don't have to rely on pywincffi.core
 libtest = None  # pylint: disable=invalid-name
 ffi = FFI()
+
+# pylint: disable=invalid-name
+skip_unless_python2 = skipUnless(PY2, "Not Python 2")
+skip_unless_python3 = skipUnless(PY3, "Not Python 3")
 
 try:
     ffi.cdef("void SetLastError(DWORD);")

--- a/pywincffi/util.py
+++ b/pywincffi/util.py
@@ -1,0 +1,59 @@
+"""
+Utility
+=======
+
+High level utilities used for converting types and working
+with Python and CFFI.  These are not part of :mod:`pywincffi.core`
+because they're not considered an internal implementation feature.
+"""
+
+from six import PY2, PY3
+
+from pywincffi.core import dist
+
+
+def string_to_cdata(string, unicode_cast=True):
+    """
+    Converts ``string`` to an equivalent cdata type depending
+    on the Python version, initial type of ``string`` and the
+    ``unicode_cast`` flag.  This function is mostly meant to
+    be used internally by pywincffi but could be used
+    elsewhere too.
+
+    :type string: str, unicode
+    :param string:
+        The string to convert to a cdata object.
+
+    :keyword bool unicode_cast:
+        If True (the default) and running Python 2 ``string`` will be
+        converted to unicode prior to being processed.
+
+        This defaults to True because pywincffi calls
+        :meth:`cffi.FFI.set_unicode` which causes types like TCHAR and
+        LPTCSTR to point to wchar_t.  In Python 3, strings are unicode by
+        default so this extra conversion step is not necessary.  In
+        Python 2 the conversion is necessary because you end up
+        subtle problems inside of the Windows APIs as a result
+
+    :raises TypeError:
+        Raised if the function can't determine how to convert
+    """
+    ffi, _ = dist.load()
+
+    if PY2 and isinstance(string, str) and unicode_cast:
+        string = unicode(string)  # pylint: disable=undefined-variable
+
+    # Convert to wchar_t if ``string`` is unicode.
+    # pylint: disable=undefined-variable
+    if PY3 and isinstance(string, str) or PY2 and isinstance(string, unicode):
+        return ffi.new("wchar_t[]", string)
+
+    # Convert to char[] if ``string`` is a regular string.  This
+    # is only for Python 2 and nly if ``force_unicode`` is False.
+    elif PY2 and isinstance(string, str):
+        return ffi.new("char[]", string)
+
+    else:
+        raise TypeError(
+            "Failed to determine how to convert the provided input, "
+            "%r (type: %s), to a cdata object" % (string, type(string)))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,83 @@
+from pywincffi.core import dist
+from pywincffi.dev.testutil import (
+    TestCase, skip_unless_python2, skip_unless_python3)
+from pywincffi.util import string_to_cdata
+
+
+class TestStringToCData(TestCase):
+    """
+    Tests for :func:`pywincffi.util.string_to_cdata`
+    """
+    def assert_type(self, cdata, expected_cname):
+        ffi, _ = dist.load()
+        typeof = ffi.typeof(cdata)
+        self.assertEqual(type(cdata).__name__, "CDataOwn")
+        self.assertEqual(typeof.kind, "array")
+        self.assertEqual(typeof.cname, expected_cname)
+
+    def assert_value(self, cdata, expected_value):
+        ffi, _ = dist.load()
+        self.assertEqual(ffi.string(cdata), expected_value)
+    #
+    # Python 2 tests
+    #
+
+    @skip_unless_python2
+    def test_py2_string_forced_to_unicode(self):
+        value = self.random_string(6)
+        cdata = string_to_cdata(str(value))
+        self.assert_type(cdata, "wchar_t[]")
+        self.assert_value(cdata, value)
+
+    @skip_unless_python2
+    def test_py2_string_explicit_conversion_to_string(self):
+        value = self.random_string(6)
+        cdata = string_to_cdata(str(value), unicode_cast=False)
+        self.assert_type(cdata, "char[]")
+        self.assert_value(cdata, value)
+
+    @skip_unless_python2
+    def test_py2_unicode(self):
+        value = self.random_string(6)
+
+        # pylint: disable=undefined-variable
+        cdata = string_to_cdata(unicode(value))
+        self.assert_type(cdata, "wchar_t[]")
+        self.assert_value(cdata, value)
+
+    @skip_unless_python2
+    def test_py2_other(self):
+        with self.assertRaises(TypeError):
+            string_to_cdata(1)
+
+    #
+    # Python 3 tests
+    #
+
+    @skip_unless_python3
+    def test_py3_string(self):
+        value = self.random_string(6)
+        cdata = string_to_cdata(value)
+        self.assert_type(cdata, "wchar_t[]")
+        self.assert_value(cdata, value)
+
+    @skip_unless_python3
+    def test_py3_unicode_cast_disabled_has_no_effect(self):
+        value = self.random_string(6)
+        cdata = string_to_cdata(value, unicode_cast=False)
+        self.assert_type(cdata, "wchar_t[]")
+        self.assert_value(cdata, value)
+
+    @skip_unless_python3
+    def test_py3_bytes(self):
+        # Bytes will probably be one type that's
+        # commonly passed in.  Since we shouldn't
+        # make assumptions about encoding we should
+        # raise a TypeError.
+        with self.assertRaises(TypeError):
+            string_to_cdata(bytes("", "utf-8"))
+
+    @skip_unless_python3
+    def test_py3_other(self):
+        with self.assertRaises(TypeError):
+            string_to_cdata(1)


### PR DESCRIPTION
This PR creates a new `pywincffi.util` module.  For now the purpose of this module is to convert a Python string to a cdata type which can then be passed to functions implemented with cffi but it could be a location for future expansion too.
