### PR TITLE
Improve Error Handling

### DIFF
--- a/pywincffi/__init__.py
+++ b/pywincffi/__init__.py
@@ -6,4 +6,4 @@ The root of the pywincffi package.  See the ``README`` and documentation for
 help and examples.
 """
 
-__version__ = (0, 1, 3)
+__version__ = (0, 2, 0)

--- a/pywincffi/exceptions.py
+++ b/pywincffi/exceptions.py
@@ -131,6 +131,7 @@ class WindowsAPIError(PyWinCFFIError):
             self.return_code, self.expected_return_code
         )
 
+
 class ResourceNotFoundError(PyWinCFFIError):
     """Raised when we fail to locate a specific resource"""
 

--- a/pywincffi/exceptions.py
+++ b/pywincffi/exceptions.py
@@ -89,6 +89,7 @@ class WindowsAPIError(PyWinCFFIError):
     :keyword int expected_return_code:
         The value we expected to receive for ``code``.
     """
+    # pylint: disable=too-many-arguments
     def __init__(self, function, error, errno,
                  return_code=None, expected_return_code=None):
         self.function = function

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -66,7 +66,7 @@ def GetStdHandle(nStdHandle):
     if handle == INVALID_HANDLE_VALUE:  # pragma: no cover
         raise WindowsAPIError(
             "GetStdHandle", "Invalid Handle", INVALID_HANDLE_VALUE,
-            "not %s" % INVALID_HANDLE_VALUE)
+            expected_return_code="not %r" % INVALID_HANDLE_VALUE)
 
     return handle
 
@@ -114,8 +114,8 @@ def WaitForSingleObject(hHandle, dwMilliseconds):
 
     if result == library.WAIT_FAILED:
         raise WindowsAPIError(
-            "WaitForSingleObject", ffi.getwinerror()[-1], result,
-            "not %s" % result)
+            "WaitForSingleObject", "Wait Failed", ffi.getwinerror()[-1],
+            return_code=result, expected_return_code="not %s" % result)
 
     error_check("WaitForSingleObject")
 

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -60,13 +60,13 @@ def pid_exists(pid, wait=0):
         # is owned by another user or the system and
         # the process running this code does not have the
         # rights to query the other process's information.
-        if error.code == library.ERROR_ACCESS_DENIED:
+        if error.errno == library.ERROR_ACCESS_DENIED:
             return True
 
         # Sometimes the PID we're asking about no longer exists
         # in the stack anywhere so we'll get ERROR_INVALID_PARAMETER
         # so there's not any reason to continue further.
-        if error.code == library.ERROR_INVALID_PARAMETER:
+        if error.errno == library.ERROR_INVALID_PARAMETER:
             return False
 
         raise

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -47,21 +47,37 @@ class TestWindowsAPIError(TestCase):
     Test case for :class:`pywincffi.exceptions.WindowsAPIError`
     """
     def test_ivar_api_function(self):
-        error = WindowsAPIError("function", "there was a problem", 1, 0)
-        self.assertEqual(error.api_function, "function")
+        error = WindowsAPIError(
+            "function", "there was a problem", 1, return_code=0)
+        self.assertEqual(error.function, "function")
 
     def test_ivar_api_error_message(self):
-        error = WindowsAPIError("function", "there was a problem", 1, 0)
-        self.assertEqual(error.api_error_message, "there was a problem")
+        error = WindowsAPIError(
+            "function", "there was a problem", 1, return_code=0)
+        self.assertEqual(error.error, "there was a problem")
 
     def test_ivar_code(self):
-        error = WindowsAPIError("function", "there was a problem", 1, 0)
-        self.assertEqual(error.code, 1)
+        error = WindowsAPIError(
+            "function", "there was a problem", 1, return_code=0)
+        self.assertEqual(error.errno, 1)
 
     def test_ivar_expected_code(self):
-        error = WindowsAPIError("function", "there was a problem", 1, 0)
-        self.assertEqual(error.expected_code, 0)
+        error = WindowsAPIError(
+            "function", "there was a problem", 1, return_code=0)
+        self.assertEqual(error.return_code, 0)
 
-    def test_str(self):
-        error = WindowsAPIError("function", "there was a problem", 1, 0)
-        self.assertEqual(str(error), error.message)
+    def test_repr(self):
+        error = WindowsAPIError(
+            "function", "there was a problem", 1, return_code=0,
+            expected_return_code=1)
+        self.assertEqual(
+            repr(error),
+            "WindowsAPIError('function', 'there was a problem', 1, "
+            "return_code=0, expected_return_code=1)"
+        )
+
+    def test_warning(self):
+
+        with self.assertWarns(Warning):
+            WindowsAPIError(
+                "function", "there was a problem", 1, return_code="foo")

--- a/tests/test_kernel32/test_process.py
+++ b/tests/test_kernel32/test_process.py
@@ -39,7 +39,7 @@ class TestOpenProcess(TestCase):
         with self.assertRaises(WindowsAPIError) as error:
             OpenProcess(0, False, os.getpid())
 
-        self.assertEqual(error.exception.code, 5)
+        self.assertEqual(error.exception.errno, 5)
 
     def test_get_process_id_current_process(self):
         # We should be able to access the pid of the process


### PR DESCRIPTION
This PR improves on the error handling by:
- Ensuring `WindowsAPIError` is more consistent and better documented
- Simplifying `error_check` and ensuring it's easier to tell what the original error was.

This came about while working on #57 where internal errors were sometimes obscuring the underlying API errors.  There are probably further improvements to be made here but this should simplify future work.
