### PR TITLE
Skip Some Tests When Internet Is Unavailable

### DIFF
--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -76,20 +76,26 @@ class TestCase(_TestCase):
 
         config.load()
 
-    def internet_connected(self):
+    @classmethod
+    def internet_connected(cls):
+        """
+        Returns ``True`` if there appears to be internet access by attempting
+        to connect to a few different domains.  The first answer will be
+        cached.
+        """
         if TestCase._HAS_INTERNET is not None:
             return TestCase._HAS_INTERNET
 
         original_timeout = socket.getdefaulttimeout()
         socket.setdefaulttimeout(1)
 
-        for hostname in ("example.com", "github.com", "readthedocs.org"):
+        for hostname in ("github.com", "readthedocs.org", "example.com"):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
                 sock.connect((hostname, 80))
                 TestCase._HAS_INTERNET = True
                 break
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 pass
             finally:
                 sock.close()

--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -59,7 +59,7 @@ class TestCase(_TestCase):
     REQUIRES_INTERNET = False
     _HAS_INTERNET = None
 
-    def setUp(self):
+    def setUp(self):  # pragma: no cover
         if self.REQUIRES_INTERNET and not self.internet_connected():
             if os.environ.get("CI"):
                 self.fail(
@@ -95,11 +95,15 @@ class TestCase(_TestCase):
                 sock.connect((hostname, 80))
                 TestCase._HAS_INTERNET = True
                 break
+
+            # pragma: no cover
             except Exception:  # pylint: disable=broad-except
                 pass
+
             finally:
                 sock.close()
-        else:
+
+        else:  # pragma: no cover
             TestCase._HAS_INTERNET = False
 
         socket.setdefaulttimeout(original_timeout)

--- a/tests/test_dev/test_release.py
+++ b/tests/test_dev/test_release.py
@@ -79,6 +79,7 @@ class TestSession(TestCase):
     """
     Tests for constants of :class:`pywincffi.dev.release.Session`
     """
+    REQUIRES_INTERNET = True
     DOWNLOAD_SHA1 = "89ff14348b410051fff2eb206183993f659d85e0"
     DOWNLOAD_URL = \
         "https://raw.githubusercontent.com/opalmer/pywincffi/" \
@@ -131,6 +132,8 @@ class TestAppVeyor(TestCase):
     """
     Tests for constants of :class:`pywincffi.dev.release.AppVeyor`
     """
+    REQUIRES_INTERNET = True
+
     def setUp(self):
         super(TestAppVeyor, self).setUp()
         self.job_id = random_string()
@@ -552,6 +555,8 @@ class TestDocsBuilt(TestCase):
     """
     Tests for :func:`pywincffi.dev.release.GitHubAPI.docs_built`
     """
+    REQUIRES_INTERNET = True
+
     def test_success(self):
         self.assertTrue(docs_built("latest"))
 


### PR DESCRIPTION
When traveling or working in a restricted VM parts of the test suite will fail.  This PR ensures that those tests are instead skipped.
