### PR TITLE
Add WriteFile Tests

### DIFF
--- a/pywincffi/kernel32/file.py
+++ b/pywincffi/kernel32/file.py
@@ -5,7 +5,7 @@ Files
 A module containing common Windows file functions for working with files.
 """
 
-from six import PY3, PY2, integer_types, string_types
+from six import PY3, integer_types, string_types
 
 from pywincffi.core import dist
 from pywincffi.core.checks import Enums, input_check, error_check
@@ -64,8 +64,12 @@ def WriteFile(hFile, lpBuffer, nNumberOfBytesToWrite=None, lpOverlapped=None,
     if lpOverlapped is None:
         lpOverlapped = ffi.NULL
 
+    lpBufferTypes = string_types
+    if PY3:
+        lpBufferTypes = tuple(list(string_types) + [bytes])
+
     input_check("hFile", hFile, Enums.HANDLE)
-    input_check("lpBuffer", lpBuffer, string_types)
+    input_check("lpBuffer", lpBuffer, lpBufferTypes)
     input_check("lpOverlapped", lpOverlapped, Enums.OVERLAPPED)
     input_check(
         "lpBufferType", lpBufferType, allowed_values=("char[]", "wchar_t[]"))

--- a/pywincffi/kernel32/file.py
+++ b/pywincffi/kernel32/file.py
@@ -12,7 +12,7 @@ from pywincffi.core.checks import Enums, input_check, error_check
 from pywincffi.util import string_to_cdata
 
 
-def WriteFile(hFile, lpBuffer, lpOverlapped=None):
+def WriteFile(hFile, lpBuffer, nNumberOfBytesToWrite=None, lpOverlapped=None):
     """
     Writes data to ``hFile`` which may be an I/O device for file.
 
@@ -27,6 +27,10 @@ def WriteFile(hFile, lpBuffer, lpOverlapped=None):
     :param lpBuffer:
         The data to be written to the file or device. We should be able
         to convert this value to unicode.
+
+    :keyword int nNumberOfBytesToWrite:
+        The number of bytes to be written.  By default this will
+        be determinted based on the size of ``lpBuffer``
 
     :type lpOverlapped: None or OVERLAPPED
     :keyword lpOverlapped:
@@ -58,13 +62,18 @@ def WriteFile(hFile, lpBuffer, lpOverlapped=None):
     input_check("lpBuffer", lpBuffer, Enums.UTF8)
     input_check("lpOverlapped", lpOverlapped, Enums.OVERLAPPED)
 
+    if nNumberOfBytesToWrite is None:
+        nNumberOfBytesToWrite = ffi.sizeof(lpBuffer)
+
+    input_check("nNumberOfBytesToWrite", nNumberOfBytesToWrite, integer_types)
+
     # Prepare string and outputs
     nNumberOfBytesToWrite = len(lpBuffer)
     lpBuffer = string_to_cdata(lpBuffer)
     bytes_written = ffi.new("LPDWORD")
 
     code = library.WriteFile(
-        hFile, lpBuffer, ffi.sizeof(lpBuffer), bytes_written, lpOverlapped)
+        hFile, lpBuffer, nNumberOfBytesToWrite, bytes_written, lpOverlapped)
     error_check("WriteFile", code=code, expected=Enums.NON_ZERO)
 
     return bytes_written[0]

--- a/pywincffi/kernel32/file.py
+++ b/pywincffi/kernel32/file.py
@@ -29,7 +29,7 @@ def WriteFile(hFile, lpBuffer, lpOverlapped=None):
         to convert this value to unicode.
 
     :type lpOverlapped: None or OVERLAPPED
-    :param lpOverlapped:
+    :keyword lpOverlapped:
         None or a pointer to a ``OVERLAPPED`` structure.  See Microsoft's
         documentation for intended usage and below for an example of this
         struct.
@@ -85,7 +85,7 @@ def ReadFile(hFile, nNumberOfBytesToRead, lpOverlapped=None):
         The number of bytes to read from ``hFile``
 
     :type lpOverlapped: None or OVERLAPPED
-    :param lpOverlapped:
+    :keyword lpOverlapped:
         None or a pointer to a ``OVERLAPPED`` structure.  See Microsoft's
         documentation for intended usage and below for an example of this
         struct.

--- a/pywincffi/kernel32/file.py
+++ b/pywincffi/kernel32/file.py
@@ -60,7 +60,7 @@ def WriteFile(hFile, lpBuffer, lpOverlapped=None):
 
     # Prepare string and outputs
     nNumberOfBytesToWrite = len(lpBuffer)
-    lpBuffer = ffi.new("wchar_t[%d]" % nNumberOfBytesToWrite, lpBuffer)
+    lpBuffer = string_to_cdata(lpBuffer)
     bytes_written = ffi.new("LPDWORD")
 
     code = library.WriteFile(

--- a/tests/test_kernel32/test_file.py
+++ b/tests/test_kernel32/test_file.py
@@ -25,17 +25,15 @@ class TestWriteFile(TestCase):
     @skip_unless_python2
     def test_python2_write_string(self):
         handle, path = self.create_handle()
-        bytes_written = WriteFile(
+        WriteFile(
             handle, "hello world", lpBufferType="char[]")
-        self.assertEqual(bytes_written, 12)
         with open(path, "r") as file_:
             self.assertEqual(file_.read(), "hello world\x00")
 
     @skip_unless_python2
     def test_python2_write_unicode(self):
         handle, path = self.create_handle()
-        bytes_written = WriteFile(handle, u"hello world")
-        self.assertEqual(bytes_written, 24)
+        WriteFile(handle, u"hello world")
         with open(path, "r") as file_:
             self.assertEqual(
                 file_.read(),
@@ -45,18 +43,15 @@ class TestWriteFile(TestCase):
     @skip_unless_python3
     def test_python3_write_string(self):
         handle, path = self.create_handle()
-        bytes_written = WriteFile(handle, "hello world")
-        self.assertEqual(bytes_written, 24)
+        WriteFile(handle, "hello world")
+        v = b"h\x00e\x00l\x00l\x00o\x00 \x00w\x00o\x00r\x00l\x00d\x00\x00\x00"
         with open(path, "rb") as file_:
-            self.assertEqual(
-                file_.read(),
-                b"h\x00e\x00l\x00l\x00o\x00 \x00w\x00o\x00r\x00l\x00d\x00\x00\x00")
+            self.assertEqual(file_.read(), v)
 
     @skip_unless_python3
     def test_python3_write_bytes(self):
         handle, path = self.create_handle()
-        bytes_written = WriteFile(handle, b"hello world")
-        self.assertEqual(bytes_written, 12)
+        WriteFile(handle, b"hello world", lpBufferType="char[]")
         with open(path, "rb") as file_:
             self.assertEqual(file_.read(), b"hello world\x00")
 

--- a/tests/test_kernel32/test_file.py
+++ b/tests/test_kernel32/test_file.py
@@ -25,7 +25,8 @@ class TestWriteFile(TestCase):
     @skip_unless_python2
     def test_python2_write_string(self):
         handle, path = self.create_handle()
-        bytes_written = WriteFile(handle, "hello world")
+        bytes_written = WriteFile(
+            handle, "hello world", lpBufferType="char[]")
         self.assertEqual(bytes_written, 12)
         with open(path, "r") as file_:
             self.assertEqual(file_.read(), "hello world\x00")
@@ -34,17 +35,22 @@ class TestWriteFile(TestCase):
     def test_python2_write_unicode(self):
         handle, path = self.create_handle()
         bytes_written = WriteFile(handle, u"hello world")
-        self.assertEqual(bytes_written, 12)
+        self.assertEqual(bytes_written, 24)
         with open(path, "r") as file_:
-            self.assertEqual(file_.read(), "hello world\x00")
+            self.assertEqual(
+                file_.read(),
+                "h\x00e\x00l\x00l\x00o\x00 \x00w\x00o\x00r\x00l"
+                "\x00d\x00\x00\x00")
 
     @skip_unless_python3
     def test_python3_write_string(self):
         handle, path = self.create_handle()
         bytes_written = WriteFile(handle, "hello world")
-        self.assertEqual(bytes_written, 12)
+        self.assertEqual(bytes_written, 24)
         with open(path, "rb") as file_:
-            self.assertEqual(file_.read(), b"hello world\x00")
+            self.assertEqual(
+                file_.read(),
+                b"h\x00e\x00l\x00l\x00o\x00 \x00w\x00o\x00r\x00l\x00d\x00\x00\x00")
 
     @skip_unless_python3
     def test_python3_write_bytes(self):

--- a/tests/test_kernel32/test_file.py
+++ b/tests/test_kernel32/test_file.py
@@ -7,8 +7,7 @@ from pywincffi.core import dist
 from pywincffi.dev.testutil import (
     TestCase, skip_unless_python2, skip_unless_python3)
 from pywincffi.exceptions import WindowsAPIError
-from pywincffi.kernel32 import (
-    MoveFileEx, WriteFile, ReadFile, CloseHandle, handle_from_file)
+from pywincffi.kernel32 import MoveFileEx, WriteFile, handle_from_file
 
 
 class TestWriteFile(TestCase):


### PR DESCRIPTION
The `WriteFile` function did not have any explicit tests before.  Due to some issues with unicode/string/byte types in Python 2 and 3 the data being written to disk was not always the same as the input provided to `lpBuffer`.  While conversion is left up to the user of `WriteFile` in the end it's now possible to provide an explict type when ffi.new is called.
