### PR TITLE
Cleanup temp files after running handle tests

### DIFF
--- a/tests/test_kernel32/test_handle.py
+++ b/tests/test_kernel32/test_handle.py
@@ -54,7 +54,8 @@ class TestGetHandleFromFile(TestCase):
             handle_from_file(0)
 
     def test_fails_if_file_is_not_open(self):
-        fd, _ = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.unlink, path)
         test_file = os.fdopen(fd, "r")
         test_file.close()
 
@@ -63,6 +64,7 @@ class TestGetHandleFromFile(TestCase):
 
     def test_opens_correct_file_handle(self):
         fd, path = tempfile.mkstemp()
+        self.addCleanup(os.unlink, path)
         os.close(fd)
 
         test_file = open(path, "w")


### PR DESCRIPTION
While working on the tests for Get/SetHandleInformation, I noticed two of the previously existing handle tests were leaving temp files behind:
- tests test_fails_if_file_is_not_open
- test_opens_correct_file_handle

This PR ensures no temp files are left after the handle tests are run.
