### PR TITLE
input_check() function does not account for ffi.error

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,15 @@ versions are shown first.
 Versions
 --------
 
+latest
+~~~~~~
+
+Notable enhancements and changes are:
+
+    * Fixed a bug where :func:`pywincffi.checks.input_check` might raise
+      ``ffi.error`` in :issue:`73`
+
+
 0.2.0
 ~~~~~
 

--- a/pywincffi/core/checks.py
+++ b/pywincffi/core/checks.py
@@ -155,7 +155,7 @@ def input_check(name, value, allowed_types=None, allowed_values=None):
                     mapping.cname.match(typeof.cname)):
                 raise TypeError
 
-        except TypeError:
+        except (TypeError, ffi.error):
             raise InputError(name, value, allowed_types)
 
     elif allowed_types is Enums.UTF8:

--- a/tests/test_core/test_checks.py
+++ b/tests/test_core/test_checks.py
@@ -30,6 +30,12 @@ class TestTypeCheckFailure(TestCase):
         with self.assertRaises(InputError):
             input_check("", ffi.new("void *[2]"), Enums.HANDLE)
 
+    def test_ffi_error_raises_input_error(self):
+        with self.assertRaises(InputError):
+            input_check(
+                "lpEventAttributes", "",
+                allowed_types=Enums.SECURITY_ATTRIBUTES)
+
 
 class TestEnumMapping(TestCase):
     def setUp(self):


### PR DESCRIPTION
When processing an enum for allowed_types `ffi.error` may be raised if the value passed in is not an object that `ffi.typeof` can understand.  This PR ensures we still raise InputError in these cases.
