### PR TITLE
Fix constant conflicts between API versions

### DIFF
--- a/pywincffi/core/cdefs/sources/main.c
+++ b/pywincffi/core/cdefs/sources/main.c
@@ -1,10 +1,28 @@
 #include <io.h>
 #include <windows.h>
 
-// Extra constants which are not defined in all versions of Windows or
-// that pywincffi creates.
-static const int FILE_FLAG_SESSION_AWARE = 0x00800000;
-static const int STARTF_UNTRUSTEDSOURCE = 0x00008000;
+// Extra constants which are not defined in all versions of the Windows
+// SDK.  If cffi fails to find the value, it ends up being picked up from
+// here.
+#if !defined(FILE_FLAG_SESSION_AWARE)
+    static const int FILE_FLAG_SESSION_AWARE = 0x00800000;
+#endif
+
+#if !defined(STARTF_UNTRUSTEDSOURCE)
+    static const int STARTF_UNTRUSTEDSOURCE = 0x00008000;
+#endif
+
+#if !defined(STARTF_PREVENTPINNING)
+    static const int STARTF_PREVENTPINNING = 0x00002000;
+#endif
+
+#if !defined(STARTF_TITLEISAPPID)
+    static const int STARTF_TITLEISAPPID = 0x00001000;
+#endif
+
+#if !defined(STARTF_TITLEISLINKNAME)
+    static const int STARTF_TITLEISLINKNAME = 0x00000800;
+#endif
 
 HANDLE handle_from_fd(int fd) {
     return (HANDLE)_get_osfhandle(fd);


### PR DESCRIPTION
In some cases the headers being used may not define certain constants.  For example the Windows API version that Python 3 is using might have the constant while the header that Python 2 picks up does not. This PR ensures that for some of the newer constants we fall back on declaring the constant rather than always declaring it.
