### PR TITLE
Created tests for SetNamedPipeHandleState

### DIFF
--- a/tests/test_kernel32/test_pipe.py
+++ b/tests/test_kernel32/test_pipe.py
@@ -155,14 +155,14 @@ class TestSetNamedPipeHandleState(PipeBaseTestCase):
         with self.assertRaises(WindowsAPIError):
             self._set_max_collection_count(10)
 
-    def _set_collect_data_timeout_null(self, timeout):
+    def _set_collect_data_timeout(self, timeout):
         reader, _ = self.create_anonymous_pipes()
         SetNamedPipeHandleState(reader, lpCollectDataTimeout=timeout)
 
     def test_collect_data_timeout_null(self):
-        self._set_collect_data_timeout_null(None)
+        self._set_collect_data_timeout(None)
 
     def test_collect_data_timeout_fail(self):
         # should fail: only supported with named pipes
         with self.assertRaises(WindowsAPIError):
-            self._set_collect_data_timeout_null(500)
+            self._set_collect_data_timeout(500)

--- a/tests/test_kernel32/test_pipe.py
+++ b/tests/test_kernel32/test_pipe.py
@@ -143,12 +143,26 @@ class TestSetNamedPipeHandleState(PipeBaseTestCase):
         _, lib = dist.load()
         self._set_mode(lib.PIPE_NOWAIT)
 
-    def test_max_collection_count_null(self):
-        # testing with anonymous pipe: only null allowed
+    def _set_max_collection_count(self, count):
         _, writer = self.create_anonymous_pipes()
-        SetNamedPipeHandleState(writer, lpMaxCollectionCount=None)
+        SetNamedPipeHandleState(writer, lpMaxCollectionCount=count)
+
+    def test_max_collection_count_null(self):
+        self._set_max_collection_count(None)
+
+    def test_max_collection_count_fail(self):
+        # should fail: only supported with named pipes
+        with self.assertRaises(WindowsAPIError):
+            self._set_max_collection_count(10)
+
+    def _set_collect_data_timeout_null(self, timeout):
+        reader, _ = self.create_anonymous_pipes()
+        SetNamedPipeHandleState(reader, lpCollectDataTimeout=timeout)
 
     def test_collect_data_timeout_null(self):
-        # testing with anonymous pipe: only null allowed
-        reader, _ = self.create_anonymous_pipes()
-        SetNamedPipeHandleState(reader, lpCollectDataTimeout=None)
+        self._set_collect_data_timeout_null(None)
+
+    def test_collect_data_timeout_fail(self):
+        # should fail: only supported with named pipes
+        with self.assertRaises(WindowsAPIError):
+            self._set_collect_data_timeout_null(500)

--- a/tests/test_kernel32/test_pipe.py
+++ b/tests/test_kernel32/test_pipe.py
@@ -2,7 +2,8 @@ from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import WindowsAPIError
 from pywincffi.kernel32 import (
     CreatePipe, PeekNamedPipe, PeekNamedPipeResult, ReadFile, WriteFile,
-    CloseHandle)
+    CloseHandle, SetNamedPipeHandleState)
+from pywincffi.core import dist
 
 # For pylint on non-windows platforms
 try:
@@ -111,3 +112,43 @@ class TestPeekNamedPipe(PipeBaseTestCase):
         result = PeekNamedPipe(reader, 0)
         self.assertEqual(
             result.lpTotalBytesAvail, bytes_written - read_bytes)
+
+
+class TestSetNamedPipeHandleState(PipeBaseTestCase):
+    """
+    Tests for :func:`pywincffi.kernel32.SetNamedPipeHandleState`.
+    """
+    def _set_mode(self, readmode):
+        reader, _ = self.create_anonymous_pipes()
+        SetNamedPipeHandleState(reader, lpMode=readmode)
+
+    def test_mode_null(self):
+        self._set_mode(None)
+
+    def test_mode_byte(self):
+        _, lib = dist.load()
+        self._set_mode(lib.PIPE_READMODE_BYTE)
+
+    def test_mode_message_fails(self):
+        _, lib = dist.load()
+        # should fail: anonymous pipes are byte oriented
+        with self.assertRaises(WindowsAPIError):
+            self._set_mode(lib.PIPE_READMODE_MESSAGE)
+
+    def test_mode_wait(self):
+        _, lib = dist.load()
+        self._set_mode(lib.PIPE_WAIT)
+
+    def test_mode_nowait(self):
+        _, lib = dist.load()
+        self._set_mode(lib.PIPE_NOWAIT)
+
+    def test_max_collection_count_null(self):
+        # testing with anonymous pipe: only null allowed
+        _, writer = self.create_anonymous_pipes()
+        SetNamedPipeHandleState(writer, lpMaxCollectionCount=None)
+
+    def test_collect_data_timeout_null(self):
+        # testing with anonymous pipe: only null allowed
+        reader, _ = self.create_anonymous_pipes()
+        SetNamedPipeHandleState(reader, lpCollectDataTimeout=None)


### PR DESCRIPTION
While reviewing tests, I found out that the SetNamedPipeHandleState wasn't being tested:
- Created a few very basic tests to ensure the wrapper is checked, at least.
- More complex tests need to be run against Named Pipes which aren't available for now.
