### PR TITLE
Fix Python Version In Intersphinx Mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,9 +50,13 @@ extensions = [
 
 linkcheck_timeout = 60
 
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/": None
+    # Hard code the Python version into the intersphinx url to ensure that the
+    # version of Python being used to build the documentation is also used
+    # in the documentation urls.  This ensures that the documentation we're
+    # building will also link to the same major version of the standard
+    # library.
+    "python": ("https://docs.python.org/%s/" % sys.version_info[0], None)
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
See comment in commit 283e08393cc8be5bcb3a057b7311f54dd2c7f3da.

In would appear that recently docs.python.org switched to using Python 3 as the standard version.  As a result when building the docs using Python 2 some Python 3 links were broken.  This PR fixes this by ensuring the url we're using matches the major Python version building the documentation.
