### PR TITLE
Fix Documentation Type References

### DIFF
--- a/pywincffi/kernel32/comms.py
+++ b/pywincffi/kernel32/comms.py
@@ -19,7 +19,7 @@ def ClearCommError(hFile):
 
         https://msdn.microsoft.com/en-us/aa363180
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         A handle to the communications device, typically created by
         :func:`CreateFile`
 

--- a/pywincffi/kernel32/events.py
+++ b/pywincffi/kernel32/events.py
@@ -116,7 +116,7 @@ def ResetEvent(hEvent):
 
         https://msdn.microsoft.com/en-us/library/ms684305
 
-    :param :class:`pywincffi.wintypes.HANDLE` hEvent:
+    :param pywincffi.wintypes.HANDLE hEvent:
         A handle to the event object to be reset. The handle must
         have the ``EVENT_MODIFY_STATE`` access right.
     """

--- a/pywincffi/kernel32/file.py
+++ b/pywincffi/kernel32/file.py
@@ -42,8 +42,7 @@ def CreateFile(  # pylint: disable=too-many-arguments
         with an explicit value, ``FILE_SHARE_READ`` will be used which will
         other open operations or process to continue to read from the file.
 
-    :type lpSecurityAttributes: :class:`pywincffi.wintypes.SECURITY_ATTRIBUTES`
-    :keyword lpSecurityAttributes:
+    :keyword pywincffi.wintypes.SECURITY_ATTRIBUTES lpSecurityAttributes:
         See Microsoft's documentation for more detailed information.
 
     :keyword int dwCreationDisposition:
@@ -56,7 +55,7 @@ def CreateFile(  # pylint: disable=too-many-arguments
         value, ``FILE_ATTRIBUTE_NORMAL`` will be used giving the handle
         essentially no special attributes.
 
-    :keyword :class:`pywincffi.wintypes.HANDLE` hTemplateFile:
+    :keyword pywincffi.wintypes.HANDLE hTemplateFile:
         A handle to a template file with the ``GENERIC_READ`` access right.
         See Microsoft's documentation for more information.  If not
         provided an explicit value, ``NULL`` will be used instead.
@@ -122,7 +121,7 @@ def WriteFile(hFile, lpBuffer, nNumberOfBytesToWrite=None, lpOverlapped=None):
 
         https://msdn.microsoft.com/en-us/library/aa365747
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         The handle to write to.
 
     :type lpBuffer: str/bytes
@@ -133,8 +132,7 @@ def WriteFile(hFile, lpBuffer, nNumberOfBytesToWrite=None, lpOverlapped=None):
     :keyword int nNumberOfBytesToWrite:
         The number of bytes to be written.  Defaults to len(lpBuffer).
 
-    :type lpOverlapped: None or :class:`pywincffi.wintypes.OVERLAPPED`
-    :keyword lpOverlapped:
+    :keyword pywincffi.wintypes.OVERLAPPED lpOverlapped:
         See Microsoft's documentation for intended usage and below for
         an example.
 
@@ -185,7 +183,7 @@ def FlushFileBuffers(hFile):
 
         https://msdn.microsoft.com/en-us/library/aa364439
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         The handle to flush to disk.
     """
     input_check("hFile", hFile, HANDLE)
@@ -202,14 +200,13 @@ def ReadFile(hFile, nNumberOfBytesToRead, lpOverlapped=None):
 
         https://msdn.microsoft.com/en-us/library/aa365467
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         The handle to read from.
 
     :param int nNumberOfBytesToRead:
         The number of bytes to read from ``hFile``
 
-    :type lpOverlapped: None or :class:`pywincffi.wintypes.OVERLAPPED`
-    :keyword lpOverlapped:
+    :keyword pywincffi.wintypes.OVERLAPPED lpOverlapped:
         See Microsoft's documentation for intended usage and below for
         an example.
 
@@ -300,7 +297,7 @@ def LockFileEx(
 
         https://msdn.microsoft.com/en-us/library/aa365203
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         The handle to the file to lock.  This handle must have been
         created with either the ``GENERIC_READ`` or ``GENERIC_WRITE``
         right.
@@ -318,8 +315,7 @@ def LockFileEx(
     :param int nNumberOfBytesToLockHigh:
         The end of the byte range to lock.
 
-    :type lpOverlapped: None or :class:`pywincffi.wintypes.OVERLAPPED`
-    :keyword lpOverlapped:
+    :keyword pywincffi.wintypes.OVERLAPPED lpOverlapped:
         The underlying Windows API requires lpOverlapped, which acts both
         an input argument and may contain results after calling. If None is
         provided, a throw-away zero-filled instance will be created to
@@ -361,7 +357,7 @@ def UnlockFileEx(
 
         https://msdn.microsoft.com/en-us/library/aa365716
 
-    :param :class:`pywincffi.wintypes.HANDLE` hFile:
+    :param pywincffi.wintypes.HANDLE hFile:
         The handle to the file to unlock.  This handle must have been
         created with either the ``GENERIC_READ`` or ``GENERIC_WRITE``
         right.
@@ -372,8 +368,7 @@ def UnlockFileEx(
     :param int nNumberOfBytesToUnlockHigh:
         The end of the byte range to unlock.
 
-    :type lpOverlapped: None or :class:`pywincffi.wintypes.OVERLAPPED`
-    :keyword lpOverlapped:
+    :keyword pywincffi.wintypes.OVERLAPPED lpOverlapped:
         The underlying Windows API requires lpOverlapped, which acts both
         an input argument and may contain results after calling. If None is
         provided, a throw-away zero-filled instance will be created to

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -52,7 +52,7 @@ def GetStdHandle(nStdHandle):
     :param int nStdHandle:
         The standard device to retrieve.
 
-    :rtype: :class:`pywincffi.wintypes.HANDLE`
+    :rtype: pywincffi.wintypes.HANDLE
     :return:
         Returns a handle to the standard device retrieved.
     """
@@ -80,7 +80,7 @@ def CloseHandle(hObject):
 
         https://msdn.microsoft.com/en-us/library/ms724211
 
-    :param :class:`pywincffi.wintypes.HANDLE` hObject:
+    :param pywincffi.wintypes.HANDLE hObject:
         The handle object to close.
     """
     input_check("hObject", hObject, HANDLE)
@@ -98,7 +98,7 @@ def GetHandleInformation(hObject):
 
         https://msdn.microsoft.com/en-us/library/ms724329
 
-    :param :class:`pywincffi.wintypes.HANDLE` hObject:
+    :param pywincffi.wintypes.HANDLE hObject:
         A handle to an object whose information is to be retrieved.
 
     :rtype: int
@@ -123,7 +123,7 @@ def SetHandleInformation(hObject, dwMask, dwFlags):
 
         https://msdn.microsoft.com/en-us/ms724935
 
-    :param :class:`pywincffi.wintypes.HANDLE` hObject:
+    :param pywincffi.wintypes.HANDLE hObject:
         A handle to an object whose information is to be set.
 
     :param int dwMask:
@@ -155,13 +155,13 @@ def DuplicateHandle(  # pylint: disable=too-many-arguments
 
         https://msdn.microsoft.com/en-us/ms724251
 
-    :param :class:`pywincffi.wintypes.HANDLE` hSourceProcessHandle:
+    :param pywincffi.wintypes.HANDLE hSourceProcessHandle:
         A handle to the process which owns the handle to be duplicated.
 
-    :param :class:`pywincffi.wintypes.HANDLE` hSourceHandle:
+    :param pywincffi.wintypes.HANDLE hSourceHandle:
         The handle to be duplicated.
 
-    :param :class:`pywincffi.wintypes.HANDLE` hTargetProcessHandle:
+    :param pywincffi.wintypes.HANDLE hTargetProcessHandle:
         A handle to the process which should receive the duplicated handle.
 
     :param int dwDesiredAccess:
@@ -180,7 +180,7 @@ def DuplicateHandle(  # pylint: disable=too-many-arguments
                parameter duplicates with the same access as the original
                handle.
 
-    :rtype: :class:`pywincffi.wintypes.HANDLE`
+    :rtype: pywincffi.wintypes.HANDLE
     :return:
         Returns the duplicated handle.
     """

--- a/pywincffi/kernel32/pipe.py
+++ b/pywincffi/kernel32/pipe.py
@@ -40,7 +40,7 @@ def CreatePipe(nSize=0, lpPipeAttributes=None):
         The size of the buffer in bytes.  Passing in 0, which is the default
         will cause the system to use the default buffer size.
 
-    :keyword :class:`pywincffi.wintypes.SECURITY_ATTRIBUTES` lpPipeAttributes:
+    :keyword pywincffi.wintypes.SECURITY_ATTRIBUTES lpPipeAttributes:
         The security attributes to apply to the handle. By default
         ``NULL`` will be passed in, meaning the handle we create
         cannot be inherited.  For more detailed information see the links
@@ -79,7 +79,7 @@ def SetNamedPipeHandleState(
 
         https://msdn.microsoft.com/en-us/library/aa365787
 
-    :param :class:`pywincffi.wintypes.HANDLE` hNamedPipe:
+    :param pywincffi.wintypes.HANDLE hNamedPipe:
         A handle to the named pipe instance.
 
     :keyword int lpMode:
@@ -141,13 +141,13 @@ def PeekNamedPipe(hNamedPipe, nBufferSize):
 
         https://msdn.microsoft.com/en-us/library/aa365779
 
-    :param :class:`pywincffi.wintypes.HANDLE` hNamedPipe:
+    :param pywincffi.wintypes.HANDLE hNamedPipe:
         The handele to the pipe object we want to peek into.
 
     :param int nBufferSize:
         The number of bytes to 'peek' into the pipe.
 
-    :rtype: :class:`PeekNamedPipeResult`
+    :rtype: PeekNamedPipeResult
     :return:
         Returns an instance of :class:`PeekNamedPipeResult` which
         contains the buffer read, number of bytes read and the result.

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -123,7 +123,7 @@ def GetExitCodeProcess(hProcess):
 
         https://msdn.microsoft.com/en-us/library/ms683189
 
-    :param :class:`pywincffi.wintypes.HANDLE` hProcess:
+    :param pywincffi.wintypes.HANDLE hProcess:
         The handle of the process to retrieve the exit code for.
 
     :returns:
@@ -203,7 +203,7 @@ def GetProcessId(Process):  # pylint: disable=invalid-name
 
         https://msdn.microsoft.com/en-us/library/ms683215
 
-    :param :class:`pywincffi.wintypes.HANDLE` Process:
+    :param pywincffi.wintypes.HANDLE Process:
         The handle of the process.
 
     :return:
@@ -225,7 +225,7 @@ def TerminateProcess(hProcess, uExitCode):
 
         https://msdn.microsoft.com/en-us/library/ms686714
 
-    :param :class:`pywincffi.wintypes.HANDLE` hProcess:
+    :param pywincffi.wintypes.HANDLE hProcess:
         A handle to the process to be terminated.
 
     :param int uExitCode:

--- a/pywincffi/kernel32/synchronization.py
+++ b/pywincffi/kernel32/synchronization.py
@@ -28,7 +28,7 @@ def WaitForSingleObject(hHandle, dwMilliseconds):
 
         https://msdn.microsoft.com/en-us/library/ms687032
 
-    :param :class:`pywincffi.wintypes.HANDLE` hHandle:
+    :param pywincffi.wintypes.HANDLE hHandle:
         The handle to wait on.
 
     :param int dwMilliseconds:


### PR DESCRIPTION
This PR fixes a problem with the type references in parameter and keyword documentation strings.  This was introduced in #90 but missed in the review process.

Here's an example of a function before this PR:
![broken](https://cloud.githubusercontent.com/assets/255117/15991542/e21acbb4-3083-11e6-8d01-ffcffd0cf2b1.jpg)

And after:
![fixed](https://cloud.githubusercontent.com/assets/255117/15991541/e216ffde-3083-11e6-82ae-6fce442529eb.jpg)
