### PR TITLE
Implement socket_from_object

### DIFF
--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -224,6 +224,11 @@ BOOL WINAPI ResetEvent(
 // Communications
 ///////////////////////
 
+// https://msdn.microsoft.com/en-us/ms737582
+int closesocket(
+  _In_ SOCKET s
+);
+
 // https://msdn.microsoft.com/en-us/aa363180
 BOOL WINAPI ClearCommError(
   _In_      HANDLE    hFile,
@@ -237,5 +242,4 @@ int WSAGetLastError(void);
 // Conversion Functions
 ///////////////////////
 HANDLE handle_from_fd(int);
-HANDLE socket_from_fd(int);
-int closesocket(SOCKET);
+SOCKET socket_from_fileno(int...);

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -231,9 +231,11 @@ BOOL WINAPI ClearCommError(
   _Out_opt_ LPCOMSTAT lpStat
 );
 
+int WSAGetLastError(void);
 
 ///////////////////////
 // Conversion Functions
 ///////////////////////
 HANDLE handle_from_fd(int);
-SOCKET socket_from_fd(int);
+HANDLE socket_from_fd(int);
+int closesocket(SOCKET);

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -236,10 +236,7 @@ BOOL WINAPI ClearCommError(
   _Out_opt_ LPCOMSTAT lpStat
 );
 
-int WSAGetLastError(void);
-
 ///////////////////////
 // Conversion Functions
 ///////////////////////
 HANDLE handle_from_fd(int);
-SOCKET socket_from_fileno(int...);

--- a/pywincffi/core/cdefs/headers/functions.h
+++ b/pywincffi/core/cdefs/headers/functions.h
@@ -145,8 +145,6 @@ BOOL WINAPI UnlockFileEx(
 // Files
 ///////////////////////
 
-HANDLE handle_from_fd(int);
-
 // https://msdn.microsoft.com/en-us/ms724211
 BOOL WINAPI CloseHandle(
   _In_ HANDLE hObject
@@ -232,3 +230,10 @@ BOOL WINAPI ClearCommError(
   _Out_opt_ LPDWORD   lpErrors,
   _Out_opt_ LPCOMSTAT lpStat
 );
+
+
+///////////////////////
+// Conversion Functions
+///////////////////////
+HANDLE handle_from_fd(int);
+SOCKET socket_from_fd(int);

--- a/pywincffi/core/cdefs/headers/typedefs.h
+++ b/pywincffi/core/cdefs/headers/typedefs.h
@@ -1,0 +1,12 @@
+//
+// This file contains type definitions that are required by other
+// headers.  In a normal C environment these would come directly
+// from the system headers.  With cffi however it has a set defined
+// types:
+//      https://bitbucket.org/cffi/cffi/raw/default/c/commontypes.c
+//
+// Any additional types we need must be defined here.  This file must
+// loaded before any other headers are in dist.py.
+//
+
+typedef int... SOCKET;

--- a/pywincffi/core/cdefs/sources/main.c
+++ b/pywincffi/core/cdefs/sources/main.c
@@ -3,25 +3,6 @@
 #include <winerror.h>
 #include <windows.h>
 #include <TlHelp32.h>
-#include <Python.h>
-
-// Copied from Python's socket module.  These are used to determine
-// how PyLong_FromSocket_t should be defined.
-#ifdef MS_WIN64
-#define SIZEOF_SOCKET_T 8
-#else
-#define SIZEOF_SOCKET_T 4
-#endif
-
-// Copied from Python's socket module.  These are considered private so we
-// wouldn't have been able to used them directly.  The resulting function,
-// PyLong_FromSocket_t, is used in socket_from_fd below.
-#if SIZEOF_SOCKET_T <= SIZEOF_LONG
-#define PyLong_FromSocket_t(fd) PyLong_FromLong((SOCKET)(fd))
-#else
-#define PyLong_FromSocket_t(fd) PyLong_FromLongLong((SOCKET)(fd))
-#endif
-
 
 // Extra constants which are not defined in all versions of the Windows
 // SDK.  If cffi fails to find the value, it ends up being picked up from
@@ -51,9 +32,8 @@ HANDLE handle_from_fd(int fd) {
 }
 
 
-// Takes a file descriptor from a Python socket and converts
-// it to a Windows SOCKET object.
-HANDLE socket_from_fd(int fd) {
-    int value = (int)PyLong_FromSocket_t(fd);
-    return handle_from_fd(value);
+// Takes the file number of a socket and converts it to
+// a Windows SOCKET object.
+SOCKET socket_from_fileno(int fileno) {
+    return (SOCKET)fileno;
 }

--- a/pywincffi/core/cdefs/sources/main.c
+++ b/pywincffi/core/cdefs/sources/main.c
@@ -1,4 +1,6 @@
 #include <io.h>
+#include <winsock2.h>
+#include <winerror.h>
 #include <windows.h>
 #include <TlHelp32.h>
 #include <Python.h>
@@ -51,6 +53,7 @@ HANDLE handle_from_fd(int fd) {
 
 // Takes a file descriptor from a Python socket and converts
 // it to a Windows SOCKET object.
-SOCKET socket_from_fd(int fd) {
-    return (SOCKET)PyLong_FromSocket_t(fd);
+HANDLE socket_from_fd(int fd) {
+    int value = (int)PyLong_FromSocket_t(fd);
+    return handle_from_fd(value);
 }

--- a/pywincffi/core/cdefs/sources/main.c
+++ b/pywincffi/core/cdefs/sources/main.c
@@ -1,6 +1,5 @@
 #include <io.h>
 #include <winsock2.h>
-#include <winerror.h>
 #include <windows.h>
 #include <TlHelp32.h>
 
@@ -29,11 +28,4 @@
 
 HANDLE handle_from_fd(int fd) {
     return (HANDLE)_get_osfhandle(fd);
-}
-
-
-// Takes the file number of a socket and converts it to
-// a Windows SOCKET object.
-SOCKET socket_from_fileno(int fileno) {
-    return (SOCKET)fileno;
 }

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -50,6 +50,8 @@ logger = get_logger("core.dist")
 MODULE_NAME = "_pywincffi"
 HEADER_FILES = (
     resource_filename(
+        "pywincffi", join("core", "cdefs", "headers", "typedefs.h")),
+    resource_filename(
         "pywincffi", join("core", "cdefs", "headers", "constants.h")),
     resource_filename(
         "pywincffi", join("core", "cdefs", "headers", "structs.h")),

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -60,7 +60,7 @@ HEADER_FILES = (
 SOURCE_FILES = (
     resource_filename(
         "pywincffi", join("core", "cdefs", "sources", "main.c")), )
-LIBRARIES = ("kernel32", "user32")
+LIBRARIES = ("kernel32", "user32", "Ws2_32")
 REGEX_SAL_ANNOTATION = re.compile(
     r"\b(_In_|_Inout_|_Out_|_Outptr_|_Reserved_)(opt_)?\b")
 

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -11,7 +11,7 @@ from six import integer_types
 from pywincffi.core import dist
 from pywincffi.core.checks import Enums, input_check, error_check
 from pywincffi.exceptions import WindowsAPIError
-from pywincffi.wintypes import HANDLE, wintype_to_cdata
+from pywincffi.wintypes import HANDLE, SOCKET, wintype_to_cdata
 
 
 INVALID_HANDLE_VALUE = -1
@@ -57,10 +57,11 @@ def CloseHandle(hObject):
 
         https://msdn.microsoft.com/en-us/library/ms724211
 
-    :param pywincffi.wintypes.HANDLE hObject:
+    :type hObject: pywincffi.wintypes.HANDLE or pywincffi.wintypes.SOCKET
+    :param hObject:
         The handle object to close.
     """
-    input_check("hObject", hObject, HANDLE)
+    input_check("hObject", hObject, (HANDLE, SOCKET))
     _, library = dist.load()
 
     code = library.CloseHandle(wintype_to_cdata(hObject))

--- a/pywincffi/wintypes/__init__.py
+++ b/pywincffi/wintypes/__init__.py
@@ -6,7 +6,8 @@ Provides user accessible types corresponding to the respective Windows types
 used across the exposed APIs.
 """
 
-from pywincffi.wintypes.functions import wintype_to_cdata, handle_from_file
+from pywincffi.wintypes.functions import (
+    wintype_to_cdata, handle_from_file, socket_from_object)
 from pywincffi.wintypes.objects import HANDLE
 from pywincffi.wintypes.structures import (
     SECURITY_ATTRIBUTES, OVERLAPPED, FILETIME)

--- a/pywincffi/wintypes/__init__.py
+++ b/pywincffi/wintypes/__init__.py
@@ -8,6 +8,6 @@ used across the exposed APIs.
 
 from pywincffi.wintypes.functions import (
     wintype_to_cdata, handle_from_file, socket_from_object)
-from pywincffi.wintypes.objects import HANDLE
+from pywincffi.wintypes.objects import HANDLE, SOCKET
 from pywincffi.wintypes.structures import (
     SECURITY_ATTRIBUTES, OVERLAPPED, FILETIME)

--- a/pywincffi/wintypes/__init__.py
+++ b/pywincffi/wintypes/__init__.py
@@ -8,6 +8,6 @@ used across the exposed APIs.
 
 from pywincffi.wintypes.functions import (
     wintype_to_cdata, handle_from_file, socket_from_object)
-from pywincffi.wintypes.objects import HANDLE, SOCKET
+from pywincffi.wintypes.objects import WrappedObject, HANDLE, SOCKET
 from pywincffi.wintypes.structures import (
     SECURITY_ATTRIBUTES, OVERLAPPED, FILETIME)

--- a/pywincffi/wintypes/functions.py
+++ b/pywincffi/wintypes/functions.py
@@ -111,4 +111,6 @@ def socket_from_object(sock):
             message="Invalid socket object (error: %s)" % error)
     else:
         ffi, _ = dist.load()
-        return SOCKET(ffi.cast("SOCKET", fileno))
+        sock = SOCKET()
+        sock._cdata[0] = ffi.cast("SOCKET", fileno)
+        return sock

--- a/pywincffi/wintypes/functions.py
+++ b/pywincffi/wintypes/functions.py
@@ -12,6 +12,12 @@ from pywincffi.core import dist
 from pywincffi.exceptions import InputError
 from pywincffi.wintypes.objects import HANDLE, SOCKET
 
+try:
+    # pylint: disable=no-member
+    SOCKET_TYPE = socket._socketobject
+except AttributeError:  # Python 3
+    SOCKET_TYPE = socket.socket
+
 
 # pylint: disable=protected-access
 def wintype_to_cdata(wintype):
@@ -88,7 +94,7 @@ def socket_from_object(sock):
 
     :rtype: :class:`pywincffi.wintypes.SOCKET`
     """
-    if not isinstance(sock, socket._socketobject):
+    if not isinstance(sock, SOCKET_TYPE):
         raise InputError(
             "sock", sock, expected_types=None,
             message="Expected a Python socket object for `sock`")

--- a/pywincffi/wintypes/functions.py
+++ b/pywincffi/wintypes/functions.py
@@ -110,5 +110,5 @@ def socket_from_object(sock):
             "sock", sock, expected_types=None,
             message="Invalid socket object (error: %s)" % error)
     else:
-        _, library = dist.load()
-        return SOCKET(library.socket_from_fileno(fileno))
+        ffi, _ = dist.load()
+        return SOCKET(ffi.cast("SOCKET", fileno))

--- a/pywincffi/wintypes/functions.py
+++ b/pywincffi/wintypes/functions.py
@@ -110,6 +110,5 @@ def socket_from_object(sock):
             "sock", sock, expected_types=None,
             message="Invalid socket object (error: %s)" % error)
     else:
-        ffi, library = dist.load()
-        sock = library.socket_from_fd(fileno)
-        return SOCKET(sock)
+        _, library = dist.load()
+        return SOCKET(library.socket_from_fileno(fileno))

--- a/pywincffi/wintypes/functions.py
+++ b/pywincffi/wintypes/functions.py
@@ -6,9 +6,11 @@ This module provides various functions for converting and using Windows
 types.
 """
 
+import socket
+
 from pywincffi.core import dist
 from pywincffi.exceptions import InputError
-from pywincffi.wintypes.objects import HANDLE
+from pywincffi.wintypes.objects import HANDLE, SOCKET
 
 
 # pylint: disable=protected-access
@@ -74,3 +76,33 @@ def handle_from_file(file_):
     else:
         _, library = dist.load()
         return HANDLE(library.handle_from_fd(fileno))
+
+
+def socket_from_object(sock):
+    """
+    Converts a Python socket to a Windows SOCKET object.
+
+    :param socket._socketobject sock:
+        The Python socket to convert to :class:`pywincffi.wintypes.SOCKET`
+        object.
+
+    :rtype: :class:`pywincffi.wintypes.SOCKET`
+    """
+    if not isinstance(sock, socket._socketobject):
+        raise InputError(
+            "sock", sock, expected_types=None,
+            message="Expected a Python socket object for `sock`")
+
+    try:
+        fileno = sock.fileno()
+    except AttributeError:
+        raise InputError(
+            "sock", sock, expected_types=None,
+            message="Expected a Python socket object for `sock`")
+    except socket.error as error:
+        raise InputError(
+            "sock", sock, expected_types=None,
+            message="Invalid socket object (error: %s)" % error)
+    else:
+        _, library = dist.load()
+        return SOCKET(library.socket_from_fd(fileno))

--- a/pywincffi/wintypes/objects.py
+++ b/pywincffi/wintypes/objects.py
@@ -56,7 +56,8 @@ class SOCKET(CFFICDataWrapper, ObjectMixin):
         ffi, _ = dist.load()
         super(SOCKET, self).__init__("SOCKET[1]", ffi)
 
-        if data is not None and not isinstance(data, integer_types):
-            raise TypeError("Expected a number for `data`")
+        if (data is not None and not
+                isinstance(data, tuple(list(integer_types) + [ffi.CData]))):
+            raise TypeError("Expected integer or CData object for `data`")
 
         self._cdata[0] = data

--- a/pywincffi/wintypes/objects.py
+++ b/pywincffi/wintypes/objects.py
@@ -30,9 +30,9 @@ class WrappedObject(CFFICDataWrapper):
 
         # Initialize from a <cdata handle> object as returned by some
         # Windows API library calls: Python AND FFI types must be equal.
-        if isinstance(data, type(self._cdata[0])):
-            if ffi.typeof(data) == ffi.typeof(self._cdata[0]):
-                self._cdata[0] = data
+        if (isinstance(data, ffi.CData) and
+                ffi.typeof(data) == ffi.typeof(self._cdata[0])):
+            self._cdata[0] = data
 
     def __repr__(self):
         ffi, _ = dist.load()

--- a/pywincffi/wintypes/objects.py
+++ b/pywincffi/wintypes/objects.py
@@ -7,6 +7,8 @@ etc.
 """
 
 # NOTE: This module should *not* import other modules from wintypes.
+from six import integer_types
+
 from pywincffi.core import dist
 from pywincffi.core.typesbase import CFFICDataWrapper
 
@@ -54,8 +56,7 @@ class SOCKET(CFFICDataWrapper, ObjectMixin):
         ffi, _ = dist.load()
         super(SOCKET, self).__init__("SOCKET[1]", ffi)
 
-        # Initialize from a <cdata handle> object as returned by some
-        # Windows API library calls: Python AND FFI types must be equal.
-        if isinstance(data, type(self._cdata[0])):
-            if ffi.typeof(data) == ffi.typeof(self._cdata[0]):
-                self._cdata[0] = data
+        if data is not None and not isinstance(data, integer_types):
+            raise TypeError("Expected a number for `data`")
+
+        self._cdata[0] = data

--- a/pywincffi/wintypes/objects.py
+++ b/pywincffi/wintypes/objects.py
@@ -46,3 +46,16 @@ class HANDLE(CFFICDataWrapper, ObjectMixin):
         if isinstance(data, type(self._cdata[0])):
             if ffi.typeof(data) == ffi.typeof(self._cdata[0]):
                 self._cdata[0] = data
+
+
+class SOCKET(CFFICDataWrapper, ObjectMixin):
+    """Handles interaction with a SOCKET object via its cdata"""
+    def __init__(self, data=None):
+        ffi, _ = dist.load()
+        super(SOCKET, self).__init__("SOCKET[1]", ffi)
+
+        # Initialize from a <cdata handle> object as returned by some
+        # Windows API library calls: Python AND FFI types must be equal.
+        if isinstance(data, type(self._cdata[0])):
+            if ffi.typeof(data) == ffi.typeof(self._cdata[0]):
+                self._cdata[0] = data

--- a/tests/test_wintypes/test_objects.py
+++ b/tests/test_wintypes/test_objects.py
@@ -1,42 +1,77 @@
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
-from pywincffi.wintypes import HANDLE
+from pywincffi.wintypes import HANDLE, SOCKET
 
 
-class TestHANDLE(TestCase):
+class ObjectBaseTestCase(TestCase):
     """
-    Tests for :class:`pywincffi.wintypes.HANDLE`
+    A base test case which wraps testing of core object
+    types.
     """
+    OBJECT_CLASS = None
+
+    def setUp(self):
+        super(ObjectBaseTestCase, self).setUp()
+
+        if self.__class__ == ObjectBaseTestCase:
+            self.skipTest("ObjectBaseTestCase not a real test")
+
+        if self.OBJECT_CLASS is None:
+            self.fail("`OBJECT_CLASS` not set")
+
+    def cast_from_value(self, int_data):
+        raise NotImplementedError
+
     def test_instantiate(self):
-        h = HANDLE()
-        self.assertIsInstance(h, HANDLE)
+        h = self.OBJECT_CLASS()  # pylint: disable=not-callable
+        self.assertIsInstance(h, self.OBJECT_CLASS)
 
     def test_compare_equal_highlevel(self):
-        h1 = HANDLE()
-        h2 = HANDLE()
+        h1 = self.OBJECT_CLASS()  # pylint: disable=not-callable
+        h2 = self.OBJECT_CLASS()  # pylint: disable=not-callable
         self.assertIsNot(h1, h2)
         self.assertEqual(h1, h2)
 
-    def _handle_from_int(self, int_data):
-        ffi, _ = dist.load()
-        cdata = ffi.new("HANDLE[1]")
-        cdata[0] = ffi.cast("HANDLE", int_data)
-        return HANDLE(cdata[0])
-
     def test_compare_equal_lowlevel(self):
-        h1 = self._handle_from_int(42)
-        h2 = self._handle_from_int(42)
+        h1 = self.cast_from_value(42)
+        h2 = self.cast_from_value(42)
         self.assertIsNot(h1, h2)
         self.assertEqual(h1, h2)
 
     def test_compare_different_lowlevel(self):
-        h1 = self._handle_from_int(42)
-        h2 = self._handle_from_int(43)
+        h1 = self.cast_from_value(42)
+        h2 = self.cast_from_value(43)
         self.assertIsNot(h1, h2)
         self.assertNotEqual(h1, h2)
 
     def test_compare_wrong_type(self):
-        h = HANDLE()
+        h = self.OBJECT_CLASS()  # pylint: disable=not-callable
         with self.assertRaises(TypeError):
             if h == 0:
                 pass
+
+
+class TestHANDLE(ObjectBaseTestCase):
+    """
+    Tests for :class:`pywincffi.wintypes.HANDLE`
+    """
+    OBJECT_CLASS = HANDLE
+
+    def cast_from_value(self, int_data):
+        ffi, _ = dist.load()
+        cdata = ffi.new(self.OBJECT_CLASS.C_TYPE)
+        cdata[0] = ffi.cast(self.OBJECT_CLASS.__name__, int_data)
+        return self.OBJECT_CLASS(cdata[0])
+
+
+class TestSOCKET(ObjectBaseTestCase):
+    """
+    Tests for :class:`pywincffi.wintypes.SOCKET`
+    """
+    OBJECT_CLASS = SOCKET
+
+    def cast_from_value(self, int_data):
+        ffi, _ = dist.load()
+        s = self.OBJECT_CLASS()
+        s._cdata[0] = ffi.cast("SOCKET", int_data)
+        return s

--- a/tests/test_wintypes/test_objects.py
+++ b/tests/test_wintypes/test_objects.py
@@ -1,6 +1,30 @@
 from pywincffi.core import dist
 from pywincffi.dev.testutil import TestCase
-from pywincffi.wintypes import HANDLE, SOCKET
+from pywincffi.wintypes import WrappedObject, HANDLE, SOCKET
+
+
+class TestWrappedObject(TestCase):
+    """
+    Tests for :class:`pywincffi.wintypes.WrappedObject`
+    """
+    def test_instantiate_without_arguments(self):
+        class INT(WrappedObject):
+            C_TYPE = "int[1]"
+
+        # This should always pass, it's a breaking change otherwise.
+        INT()
+
+    def test_requires_c_type(self):
+        with self.assertRaises(NotImplementedError):
+            WrappedObject()
+
+    def test_declares_proper_cname(self):
+        class INT(WrappedObject):
+            C_TYPE = "int[1]"
+
+        ffi, _ = dist.load()
+        int_ = INT()
+        self.assertEqual(ffi.typeof(int_._cdata).cname, INT.C_TYPE)
 
 
 class ObjectBaseTestCase(TestCase):
@@ -25,6 +49,10 @@ class ObjectBaseTestCase(TestCase):
     def test_instantiate(self):
         h = self.OBJECT_CLASS()  # pylint: disable=not-callable
         self.assertIsInstance(h, self.OBJECT_CLASS)
+
+    def test_is_wrapped_object(self):
+        # pylint: disable=not-callable
+        self.assertIsInstance(self.OBJECT_CLASS(), WrappedObject)
 
     def test_compare_equal_highlevel(self):
         h1 = self.OBJECT_CLASS()  # pylint: disable=not-callable


### PR DESCRIPTION
This PR adds a new function, socket_from_object, which can convert a Python socket object to a windows SOCKET type.  It will also consolidate some of the existing code around object types.
