### PR TITLE
Enhancements for core.dist

### DIFF
--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -133,7 +133,7 @@ class LibraryWrapper(object):  # pylint: disable=too-few-public-methods
             # runtime constants so it shouldn't exist.
             raise initial_exception
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "%s(%r)" % (self.__class__.__name__, self._library)
 
 

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -26,7 +26,7 @@ from pkg_resources import resource_filename
 from cffi import FFI
 
 from pywincffi.core.logger import get_logger
-from pywincffi.exceptions import ResourceNotFoundError
+from pywincffi.exceptions import ResourceNotFoundError, InternalError
 
 imp = None  # pylint: disable=invalid-name
 ExtensionFileLoader = None  # pylint: disable=invalid-name
@@ -148,13 +148,13 @@ class Loader(object):
         """
         Establishes the cache.
 
-        :raises RuntimeError:
+        :raises pywincffi.exceptions.InternalError:
             Raised if the cache was already setup once.
         """
         if cls.cache is not None:
             # Setting up the cache multiple times is an indication of a
             # possible bug.
-            raise RuntimeError("The cache has already been established")
+            raise InternalError("The cache has already been established")
 
         cls.cache = (ffi, library)
 
@@ -163,12 +163,12 @@ class Loader(object):
         """
         Retrieves the current cache.
 
-        :raises ValueError:
+        :raises pywincffi.exceptions.InternalError:
             Raised if an attempt is made to retrieve the cache when it
             has not been setup yet.
         """
         if cls.cache is None:
-            raise ValueError("The cache has not been established yet")
+            raise InternalError("The cache has not been established yet")
         return cls.cache
 
 
@@ -306,7 +306,7 @@ def load():
     """
     try:
         return Loader.get()
-    except ValueError:
+    except InternalError:
         try:
             import _pywincffi as pywincffi
         except ImportError:

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -93,6 +93,11 @@ class LibraryWrapper(object):  # pylint: disable=too-few-public-methods
         self._library = library
 
     def __dir__(self):
+        """
+        Overrides the default ``__dir__`` function so functions such as
+        :func:`dir` return the attributes of the underlying library plus
+        the runtime constants.
+        """
         return dir(self._library) + list(self._RUNTIME_CONSTANTS.keys())
 
     def __getattribute__(self, item):

--- a/pywincffi/core/dist.py
+++ b/pywincffi/core/dist.py
@@ -137,6 +137,41 @@ class LibraryWrapper(object):  # pylint: disable=too-few-public-methods
         return "%s(%r)" % (self.__class__.__name__, self._library)
 
 
+class Loader(object):
+    """
+    A class which provides a cache for :func:`load`.
+    """
+    cache = None
+
+    @classmethod
+    def set(cls, ffi, library):
+        """
+        Establishes the cache.
+
+        :raises RuntimeError:
+            Raised if the cache was already setup once.
+        """
+        if cls.cache is not None:
+            # Setting up the cache multiple times is an indication of a
+            # possible bug.
+            raise RuntimeError("The cache has already been established")
+
+        cls.cache = (ffi, library)
+
+    @classmethod
+    def get(cls):
+        """
+        Retrieves the current cache.
+
+        :raises ValueError:
+            Raised if an attempt is made to retrieve the cache when it
+            has not been setup yet.
+        """
+        if cls.cache is None:
+            raise ValueError("The cache has not been established yet")
+        return cls.cache
+
+
 def _import_path(path, module_name=MODULE_NAME):
     """
     Function which imports ``path`` and returns it as a module.  This is
@@ -262,41 +297,6 @@ def _compile(ffi, tmpdir=None, module_name=MODULE_NAME):
     shutil.rmtree(tmpdir, ignore_errors=True)
 
     return module
-
-
-class Loader(object):
-    """
-    A class which provides a cache for :func:`load`.
-    """
-    cache = None
-
-    @classmethod
-    def set(cls, ffi, library):
-        """
-        Establishes the cache.
-
-        :raises RuntimeError:
-            Raised if the cache was already setup once.
-        """
-        if cls.cache is not None:
-            # Setting up the cache multiple times is an indication of a
-            # possible bug.
-            raise RuntimeError("The cache has already been established")
-
-        cls.cache = (ffi, library)
-
-    @classmethod
-    def get(cls):
-        """
-        Retrieves the current cache.
-
-        :raises ValueError:
-            Raised if an attempt is made to retrieve the cache when it
-            has not been setup yet.
-        """
-        if cls.cache is None:
-            raise ValueError("The cache has not been established yet")
-        return cls.cache
 
 
 def load():

--- a/pywincffi/exceptions.py
+++ b/pywincffi/exceptions.py
@@ -16,14 +16,6 @@ class PyWinCFFIError(Exception):
     """
 
 
-class PyWinCFFINotImplementedError(PyWinCFFIError):
-    """
-    Raised if we encounter a situation where we can't figure out what
-    to do.  The message for this error should contain all the information
-    necessary to implement a future work around.
-    """
-
-
 class InputError(PyWinCFFIError):
     """
     A subclass of :class:`PyWinCFFIError` that's raised when invalid input
@@ -161,9 +153,25 @@ class WindowsAPIError(PyWinCFFIError):
         )
 
 
-class ResourceNotFoundError(PyWinCFFIError):
+class InternalError(PyWinCFFIError):
+    """
+    Raised if we encounter an internal error.  Most likely this is an
+    indication of a bug in pywincffi but it could also be a problem caused by
+    an unexpected use case.
+    """
+
+
+class PyWinCFFINotImplementedError(InternalError):
+    """
+    Raised if we encounter a situation where we can't figure out what
+    to do.  The message for this error should contain all the information
+    necessary to implement a future work around.
+    """
+
+
+class ResourceNotFoundError(InternalError):
     """Raised when we fail to locate a specific resource"""
 
 
-class ConfigurationError(PyWinCFFIError):
+class ConfigurationError(InternalError):
     """Raised when there was a problem with the configuration file"""

--- a/pywincffi/kernel32/handle.py
+++ b/pywincffi/kernel32/handle.py
@@ -14,9 +14,6 @@ from pywincffi.exceptions import WindowsAPIError
 from pywincffi.wintypes import HANDLE, SOCKET, wintype_to_cdata
 
 
-INVALID_HANDLE_VALUE = -1
-
-
 def GetStdHandle(nStdHandle):
     """
     Retrieves a handle to the specified standard
@@ -41,10 +38,10 @@ def GetStdHandle(nStdHandle):
 
     handle = library.GetStdHandle(nStdHandle)
 
-    if handle == INVALID_HANDLE_VALUE:  # pragma: no cover
+    if handle == library.INVALID_HANDLE_VALUE:  # pragma: no cover
         raise WindowsAPIError(
-            "GetStdHandle", "Invalid Handle", INVALID_HANDLE_VALUE,
-            expected_return_code="not %r" % INVALID_HANDLE_VALUE)
+            "GetStdHandle", "Invalid Handle", library.INVALID_HANDLE_VALUE,
+            expected_return_code="not %r" % library.INVALID_HANDLE_VALUE)
 
     return HANDLE(handle)
 

--- a/pywincffi/kernel32/process.py
+++ b/pywincffi/kernel32/process.py
@@ -25,7 +25,6 @@ from pywincffi.kernel32.synchronization import WaitForSingleObject
 from pywincffi.wintypes import HANDLE, wintype_to_cdata
 
 RESERVED_PIDS = set([0, 4])
-INVALID_HANDLE_VALUE = -1
 
 
 def pid_exists(pid, wait=0):
@@ -272,10 +271,11 @@ def CreateToolhelp32Snapshot(dwFlags, th32ProcessID):
         ffi.cast("DWORD", th32ProcessID)
     )
 
-    if process_list == INVALID_HANDLE_VALUE:  # pragma: no cover
+    if process_list == library.INVALID_HANDLE_VALUE:  # pragma: no cover
         raise WindowsAPIError(
-            "CreateToolhelp32Snapshot", "Invalid Handle", INVALID_HANDLE_VALUE,
-            expected_return_code="not %r" % INVALID_HANDLE_VALUE)
+            "CreateToolhelp32Snapshot", "Invalid Handle",
+            library.INVALID_HANDLE_VALUE,
+            expected_return_code="not %r" % library.INVALID_HANDLE_VALUE)
 
     error_check("CreateToolhelp32Snapshot")
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 from pywincffi.dev.testutil import TestCase
 from pywincffi.exceptions import (
-    PyWinCFFIError, InputError, WindowsAPIError, PyWinCFFINotImplementedError)
+    PyWinCFFIError, InternalError, InputError, WindowsAPIError,
+    PyWinCFFINotImplementedError, ResourceNotFoundError, ConfigurationError)
 
 
 class TestBaseClasses(TestCase):
@@ -19,6 +20,14 @@ class TestBaseClasses(TestCase):
     def test_notimplementederror(self):
         self.assertTrue(
             issubclass(PyWinCFFINotImplementedError, PyWinCFFIError))
+
+    def test_internalerror(self):
+        self.assertTrue(
+            issubclass(PyWinCFFINotImplementedError, InternalError))
+        self.assertTrue(
+            issubclass(ResourceNotFoundError, InternalError))
+        self.assertTrue(
+            issubclass(ConfigurationError, InternalError))
 
 
 class TestInputError(TestCase):


### PR DESCRIPTION
This PR brings a few improvements to the `core.dist` module:
- A `LibraryWrapper` class so we can add non-compiled constants to the library that ffi returns.  This removes the need to define constants such as `INVALID_HANLE_VALUE` in individual modules.
- Simplified caching
- A new `InternalError` exception so we're not raising RuntimeError/ValueError/etc when pywincffi itself is the library throwing the rrror.
