### PR TITLE
Improve Error Checks In Tests

### DIFF
--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -299,5 +299,4 @@ class TestCase(_TestCase):  # pylint: disable=too-many-public-methods
         """
         last_error, _ = self.GetLastError()
         self.assertIn(last_error, (0, errno))
-        if last_error != 0:
-            self.SetLastError(0)
+        self.SetLastError(0)

--- a/pywincffi/dev/testutil.py
+++ b/pywincffi/dev/testutil.py
@@ -278,3 +278,26 @@ class TestCase(_TestCase):  # pylint: disable=too-many-public-methods
             output += choice(ascii_lowercase + ascii_uppercase + "0123456789")
 
         return output
+
+    def assert_last_error(self, errno):
+        """
+        This function will assert that the last unhandled error
+        was ``errno``.  After the check the last error will be reset to
+        zero.
+
+        :param int errno:
+            The expected value from GetLastError.
+        """
+        last_error, _ = self.GetLastError()
+        self.assertEqual(last_error, errno)
+        self.SetLastError(0)
+
+    def maybe_assert_last_error(self, errno):
+        """
+        This function is similar to :meth:`assert_last_error` except
+        it won't fail if the current error number is already 0.
+        """
+        last_error, _ = self.GetLastError()
+        self.assertIn(last_error, (0, errno))
+        if last_error != 0:
+            self.SetLastError(0)

--- a/tests/test_kernel32/test_comms.py
+++ b/tests/test_kernel32/test_comms.py
@@ -6,7 +6,7 @@ from pywincffi.exceptions import WindowsAPIError
 
 class TestClearCommError(TestCase):
     def test_clear_error(self):
-        ffi, library = dist.load()
+        _, library = dist.load()
 
         # Try to find a COM device, skip the test if we can't
         # find one.  The 'maximum' comes from here:
@@ -25,10 +25,7 @@ class TestClearCommError(TestCase):
                 ClearCommError(handle)
                 break
             except WindowsAPIError:
-                code, _ = ffi.getwinerror()
-                if code != library.ERROR_FILE_NOT_FOUND:
-                    self.fail("Unexpected Windows API error: %s" % code)
-                self.SetLastError(0)  # cleanup after the failure
+                self.assert_last_error(library.ERROR_FILE_NOT_FOUND)
 
         if not found_com_device:
             self.skipTest("No COM devices present.")

--- a/tests/test_kernel32/test_events.py
+++ b/tests/test_kernel32/test_events.py
@@ -66,8 +66,7 @@ class TestCreateEvent(TestCase):
         self.addCleanup(CloseHandle, handle2)
 
         _, library = dist.load()
-        self.assertEqual(self.GetLastError()[0], library.ERROR_ALREADY_EXISTS)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_ALREADY_EXISTS)
 
     def test_raises_non_error_already_exists(self):
         def raise_(*_):

--- a/tests/test_kernel32/test_file.py
+++ b/tests/test_kernel32/test_file.py
@@ -173,7 +173,6 @@ class TestCreateFile(TestCase):
 
         path = text_type(path)  # pylint: disable=redefined-variable-type
         handle = CreateFile(path, 0)
-        self.SetLastError(0)
         self.addCleanup(os.remove, path)
         self.addCleanup(CloseHandle, handle)
         self.assertTrue(isfile(path))
@@ -193,8 +192,7 @@ class TestCreateFile(TestCase):
         self.addCleanup(CloseHandle, handle)
 
         _, library = dist.load()
-        self.assertEqual(self.GetLastError()[0], library.ERROR_ALREADY_EXISTS)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_ALREADY_EXISTS)
 
         with open(path, "r") as file_:
             self.assertEqual(file_.read(), "")
@@ -225,7 +223,7 @@ class TestCreateFile(TestCase):
                 u"", 0, dwCreationDisposition=library.CREATE_ALWAYS)
             self.addCleanup(CloseHandle, handle)
 
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_PATH_NOT_FOUND)
         self.assertEqual(error.exception.errno, library.ERROR_PATH_NOT_FOUND)
 
 
@@ -239,7 +237,7 @@ class LockFileCase(TestCase):
         _, library = dist.load()
         path = text_type(path)  # pylint: disable=redefined-variable-type
         self.handle = CreateFile(path, library.GENERIC_WRITE)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_ALREADY_EXISTS)
         self.addCleanup(CloseHandle, self.handle)
 
         WriteFile(self.handle, b"hello")

--- a/tests/test_kernel32/test_pipe.py
+++ b/tests/test_kernel32/test_pipe.py
@@ -61,6 +61,9 @@ class AnonymousPipeReadWriteTest(PipeBaseTestCase):
             ReadFile(reader, bytes_written),
             b"hello world")
 
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
+
 
 # TODO: tests for lpBuffer from the result
 class TestPeekNamedPipe(PipeBaseTestCase):
@@ -70,6 +73,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
     def test_return_type(self):
         reader, _ = self.create_anonymous_pipes()
         self.assertIsInstance(PeekNamedPipe(reader, 0), PeekNamedPipeResult)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
     def test_peek_does_not_remove_data(self):
         reader, writer = self.create_anonymous_pipes()
@@ -79,6 +84,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
 
         PeekNamedPipe(reader, 0)
         self.assertEqual(ReadFile(reader, data_written), data)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
     def test_bytes_read_less_than_bytes_written(self):
         reader, writer = self.create_anonymous_pipes()
@@ -88,6 +95,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
 
         result = PeekNamedPipe(reader, 1)
         self.assertEqual(result.lpBytesRead, 1)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
     def test_bytes_read_greater_than_bytes_written(self):
         reader, writer = self.create_anonymous_pipes()
@@ -97,6 +106,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
 
         result = PeekNamedPipe(reader, bytes_written * 2)
         self.assertEqual(result.lpBytesRead, bytes_written)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
     def test_total_bytes_avail(self):
         reader, writer = self.create_anonymous_pipes()
@@ -106,6 +117,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
 
         result = PeekNamedPipe(reader, 0)
         self.assertEqual(result.lpTotalBytesAvail, bytes_written)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
     def test_total_bytes_avail_after_read(self):
         reader, writer = self.create_anonymous_pipes()
@@ -119,6 +132,8 @@ class TestPeekNamedPipe(PipeBaseTestCase):
         result = PeekNamedPipe(reader, 0)
         self.assertEqual(
             result.lpTotalBytesAvail, bytes_written - read_bytes)
+        _, library = dist.load()
+        self.maybe_assert_last_error(library.ERROR_INVALID_HANDLE)
 
 
 class TestSetNamedPipeHandleState(PipeBaseTestCase):

--- a/tests/test_kernel32/test_pipe.py
+++ b/tests/test_kernel32/test_pipe.py
@@ -35,16 +35,14 @@ class CreatePipeTest(TestCase):
             CloseHandle(writer)
 
         _, library = dist.load()
-        self.assertEqual(self.GetLastError()[0], library.ERROR_INVALID_HANDLE)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_INVALID_HANDLE)
 
         # Second attempt should fail
         CloseHandle(reader)
         with self.assertRaises(WindowsAPIError):
             CloseHandle(reader)
 
-        self.assertEqual(self.GetLastError()[0], library.ERROR_INVALID_HANDLE)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_INVALID_HANDLE)
 
 
 class AnonymousPipeReadWriteTest(PipeBaseTestCase):
@@ -157,9 +155,7 @@ class TestSetNamedPipeHandleState(PipeBaseTestCase):
         with self.assertRaises(WindowsAPIError):
             self._set_mode(lib.PIPE_READMODE_MESSAGE)
 
-        self.assertEqual(
-            self.GetLastError()[0], lib.ERROR_INVALID_PARAMETER)
-        self.SetLastError(0)
+        self.assert_last_error(lib.ERROR_INVALID_PARAMETER)
 
     def test_mode_wait(self):
         _, lib = dist.load()
@@ -182,9 +178,7 @@ class TestSetNamedPipeHandleState(PipeBaseTestCase):
             self._set_max_collection_count(10)
 
         _, library = dist.load()
-        self.assertEqual(
-            self.GetLastError()[0], library.ERROR_INVALID_PARAMETER)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_INVALID_PARAMETER)
 
     def _set_collect_data_timeout(self, timeout):
         reader, _ = self.create_anonymous_pipes()
@@ -199,6 +193,4 @@ class TestSetNamedPipeHandleState(PipeBaseTestCase):
             self._set_collect_data_timeout(500)
 
         _, library = dist.load()
-        self.assertEqual(
-            self.GetLastError()[0], library.ERROR_INVALID_PARAMETER)
-        self.SetLastError(0)
+        self.assert_last_error(library.ERROR_INVALID_PARAMETER)

--- a/tests/test_wintypes/test_functions.py
+++ b/tests/test_wintypes/test_functions.py
@@ -97,5 +97,4 @@ class TestSocketFromObject(TestCase):
         # Socket is already closed so closesocket should fail.
         self.assertEqual(library.closesocket(sock._cdata[0]), -1)
 
-        self.assertEqual(self.GetLastError()[0], library.WSAENOTSOCK)
-        self.SetLastError(0)
+        self.assert_last_error(library.WSAENOTSOCK)


### PR DESCRIPTION
This PR makes a couple of improvements to error checking in tests.  Namely:
- There's now a function for checking the result of `GetLastError()` while also resetting the value.
- Some tests which were flaky now call `maybe_assert_last_error()`.  This ensures that if an error it's not something unexpected.  This function also ensures that the current error is set back to 0.
