### PR TITLE
Release 0.4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Python Windows Wrapper Using CFFI
     :target: https://codecov.io/github/opalmer/pywincffi?branch=master
     :alt: code coverage
 
-.. image:: https://readthedocs.org/projects/pywincffi/badge/?version=0.3.1
+.. image:: https://readthedocs.org/projects/pywincffi/badge/?version=0.4.0
     :target: https://pywincffi.readthedocs.org/
     :alt: documentation badge
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,8 +8,8 @@ versions are shown first.
 Versions
 --------
 
-latest
-~~~~~~
+0.4.0
+~~~~~
 
 Notable enhancements and changes are:
 

--- a/pywincffi/__init__.py
+++ b/pywincffi/__init__.py
@@ -6,4 +6,4 @@ The root of the pywincffi package.  See the ``README`` and documentation for
 help and examples.
 """
 
-__version__ = (0, 3, 1)
+__version__ = (0, 4, 0)


### PR DESCRIPTION
This PR prepares for the 0.4.0 release.  See the [milestone](https://github.com/opalmer/pywincffi/issues?utf8=%E2%9C%93&q=milestone%3A0.4.0%20) for more information.
