### PR TITLE
Use environment markers to override pytest version for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3.6
 
 env:
   - READTHEDOCS=1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,6 @@
-pytest
+pytest==3.2.5; python_version == '3.3'
+pytest; python_version == '2.7'
+pytest; python_version > '3.3'
 pytest-cov
 unittest2
 pylint==1.7.4


### PR DESCRIPTION
py.test has dropped support for Python 3.3 in version 3.3.0:

https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#pytest-330-2017-11-23

Specifically, pytest-dev/pytest@e87ff07 now causes pip to prevent py.test from being installed which breaks the build. This project still needs to support Python 3.3 however because it only reached end of life in September of 2017 and Twisted still appears to support Python 3.3 too. Because there's no real overhead for pywincffi to continue to support Python 3.3, other than a slower build, there's not really a good reason to drop it from the build at this time.